### PR TITLE
feat: add support for remote_servers secret configuration

### DIFF
--- a/charts/clickhouse/templates/chi.yaml
+++ b/charts/clickhouse/templates/chi.yaml
@@ -33,6 +33,12 @@ spec:
           secretKeyRef:
             name: {{ include "clickhouse.credentialsName" . }}
             key: password
+    settings:
+      remote_servers/{{ include "clickhouse.clustername" . }}/secret:
+        valueFrom:
+          secretKeyRef:
+            name: {{ include "clickhouse.credentialsName" . }}
+            key: password
     clusters:
       - name: {{ include "clickhouse.clustername" . }}
         layout:


### PR DESCRIPTION
## Pull Request Description

This PR introduces support for configuring `remote_servers` in the ClickHouseInstallation resource with secret-based authentication.

Error `DB::Exception: default: Authentication failed: password is incorrect, or there is no user with such name.` occurs because the Distributed table is unable to connect to another server in the cluster. By default, shards use the default user to connect to each other. You can resolve this issue by:

1. Configuring a remote_servers entry with a specified user and password pair.
2. Removing the password for the default user to allow seamless local connections.

> [!NOTE]
> The current Altinity Helm chart for ClickHouse installations does not support configuring remote_servers. As a workaround, you can use the default user without a password. This setup is secure as it restricts access to local connections only.

Key Changes:
- Updated chi.yaml to include a new `settings` section for `remote_servers` using the Helm chart's templating with dynamically configured via Kubernetes Secret references.

### Reviewer Notes:

Please ensure that:
- Secrets are properly defined in your Kubernetes cluster before deploying.
- The changes align with your current security and deployment workflows.