### PR TITLE
Add CHK to provision keeper

### DIFF
--- a/charts/clickhouse/Chart.lock
+++ b/charts/clickhouse/Chart.lock
@@ -1,9 +1,6 @@
 dependencies:
-- name: clickhouse-keeper-sts
-  repository: https://helm.altinity.com
-  version: 0.1.5
 - name: altinity-clickhouse-operator
   repository: https://docs.altinity.com/clickhouse-operator
-  version: 0.23.6
-digest: sha256:939229b2beb0f969689638b7b7dcd581cbe3f6561052a5328b46e72986fe346d
-generated: "2024-12-02T13:25:33.014013-05:00"
+  version: 0.24.3
+digest: sha256:b94131a88dd2045295643ffb85cd0c84c723e86c0513df7308c527e19ee80cc2
+generated: "2025-01-28T13:19:50.741222228+01:00"

--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,17 +2,12 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for creating a ClickHouse® Cluster with the Altinity Operator for ClickHouse
 type: application
-version: 0.1.7
-appVersion: "23.8.8.21"
+version: 0.2.0
+appVersion: "24.3.12.76"
 
 dependencies:
-  - name: clickhouse-keeper-sts
-    repository: https://helm.altinity.com
-    version: 0.1.5
-    alias: keeper
-    condition: keeper.enabled
   - name: altinity-clickhouse-operator
     repository: https://docs.altinity.com/clickhouse-operator
-    version: 0.23.6
+    version: 0.24.3
     alias: operator
     condition: operator.enabled

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -10,8 +10,7 @@ A Helm chart for creating a ClickHouse Cluster with the Altinity Operator for Cl
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://docs.altinity.com/clickhouse-operator | operator(altinity-clickhouse-operator) | 0.23.6 |
-| https://helm.altinity.com | keeper(clickhouse-keeper-sts) | 0.1.3 |
+| https://docs.altinity.com/clickhouse-operator | operator(altinity-clickhouse-operator) | 0.24.3 |
 
 ## Installing the Chart
 
@@ -20,7 +19,7 @@ A Helm chart for creating a ClickHouse Cluster with the Altinity Operator for Cl
 helm repo add kubernetes-blueprints-for-clickhouse https://altinity.github.io/kubernetes-blueprints-for-clickhouse
 
 # use this command to install clickhouse chart (it will also create a `clickhouse` namespace)
-helm install ch kubernetes-blueprints-for-clickhouse/clickhouse --namespace clickhouse --create-namespace
+helm install --create-namespace --namespace clickhouse eks-dev  --set keeper.enabled=true --set clickhouse.replicasCount=2
 ```
 
 > Use `-f` flag to override default values: `helm install -f newvalues.yaml`
@@ -65,7 +64,7 @@ kubectl exec -it chi-eks-dev-0-0-0 --namespace clickhouse -- clickhouse-client
 | clickhouse.defaultUser.password | string | `""` |  |
 | clickhouse.image.pullPolicy | string | `"IfNotPresent"` |  |
 | clickhouse.image.repository | string | `"altinity/clickhouse-server"` |  |
-| clickhouse.image.tag | string | `"23.8.8.21.altinitystable"` | Override the image tag for a specific version |
+| clickhouse.image.tag | string | `"24.3.12.76.altinitystable"` | Override the image tag for a specific version |
 | clickhouse.keeper | object | `{"host":"","port":2181}` | Keeper connection settings for ClickHouse instances. |
 | clickhouse.keeper.host | string | `""` | Specify a keeper host. Should be left empty if `clickhouse-keeper.enabled` is `true`. Will override the defaults set from `clickhouse-keeper.enabled`. |
 | clickhouse.keeper.port | int | `2181` | Override the default keeper port |
@@ -80,7 +79,22 @@ kubectl exec -it chi-eks-dev-0-0-0 --namespace clickhouse -- clickhouse-client
 | clickhouse.podLabels | object | `{}` |  |
 | clickhouse.replicasCount | int | `1` | number of replicas. If greater than 1, keeper must be enabled or a keeper host should be provided under clickhouse.keeper.host.  Will be ignored if `zones` is set. |
 | clickhouse.service.type | string | `"ClusterIP"` |  |
+| clickhouse.service.lbService.enable | bool | `false` | additional cluster LB service |
+| clickhouse.service.lbService.serviceAnnotations | object | `""` | annotations for the LB service |
 | clickhouse.zones | list | `[]` |  |
 | keeper.enabled | bool | `false` | Whether to enable Keeper. Required for replicated tables. |
 | keeper.replicaCount | int | `3` | Number of keeper replicas. Must be an odd number. !! DO NOT CHANGE AFTER INITIAL DEPLOYMENT |
+| keeper.image | string | `"altinity/clickhouse-keeper"` |  |
+| keeper.tag | string | `"24.3.12.76.altinitystable"` |  |
+| keeper.settings | object | `[]` | `clickhouse-keeper` global config, for example: `prometheus/port: "7000"` |
+| keeper.localStorage.size | string | `"5Gi"` | size for keeper PV |
+| keeper.localStorage.storageClass | string | `""` | storage class for keeper PV |
+| keeper.nodeSelector | object | `{}` |  |
+| keeper.tolerations | object | `{}` |  |
+| keeper.zoneSpread | bool | `false` | topologySpreadConstraints over `zone`, by deafult there is only podAntiAffinity by hostname |
+| keeper.metricsPort | string | `""` | add metrics port to the service and pod |
+| keeper.resources.cpuRequestsMs | string | `"250m"` |  |
+| keeper.resources.memoryRequestsMiB | string | `"128Mi"` |  |
+| keeper.resources.cpuLimitsMs | string | `"500m"` |  |
+| keeper.resources.memoryLimitsMiB | string | `"128Mi"` |  |
 | operator.enabled | bool | `true` | Whether to enabled the Altinity Operator for ClickHouse. Disable if you already have the Operator installed cluster-wide. |

--- a/charts/clickhouse/examples/values-production-2zones-3replicas-mini.yaml
+++ b/charts/clickhouse/examples/values-production-2zones-3replicas-mini.yaml
@@ -1,12 +1,15 @@
 clickhouse:
   antiAffinity: true
   replicasCount: 3
+  lbService:
+    enabled: true
+    serviceAnnotations:
+      minikube.io/lb: "internal"
   nodeSelector:
-    node.kubernetes.io/instance-type: "m7i.large"
+    node.kubernetes.io/instance-type: "minikube-node"
   persistence:
     enabled: true
-    size: 50Gi
-    storageClass: gp3-encrypted
+    size: 5Gi
   topologySpreadConstraints:
   - maxSkew: 1
     topologyKey: topology.kubernetes.io/zone
@@ -20,8 +23,7 @@ keeper:
   replicaCount: 3
   zoneSpread: true
   localStorage:
-    size: 5Gi
-    storageClass: gp3-encrypted
+    size: 1Gi
   metricsPort: 7000
   settings:
     prometheus/endpoint: /metrics
@@ -33,3 +35,8 @@ keeper:
   podAnnotations:
     prometheus.io/port: "7000"
     prometheus.io/scrape: "true"
+  resources:
+    cpuRequestsMs: "250m"
+    memoryRequestsMiB: "128Mi"
+    cpuLimitsMs: "500m"
+    memoryLimitsMiB: "128Mi"

--- a/charts/clickhouse/examples/values-production-2zones-3replicas.yaml
+++ b/charts/clickhouse/examples/values-production-2zones-3replicas.yaml
@@ -1,14 +1,19 @@
 clickhouse:
   antiAffinity: true
-  zones:
-    - us-west-2a
-    - us-west-2b
+  replicasCount: 3
   nodeSelector:
     node.kubernetes.io/instance-type: "m7i.large"
   persistence:
     enabled: true
     size: 50Gi
     storageClass: gp3-encrypted
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        clickhouse-keeper.altinity.com/cluster: chk-test
 
 keeper:
   enabled: true

--- a/charts/clickhouse/templates/_helpers.tpl
+++ b/charts/clickhouse/templates/_helpers.tpl
@@ -103,6 +103,10 @@ Pod Template Base
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.clickhouse.topologySpreadConstraints }}
+          topologySpreadConstraints:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
 {{- end -}}
 
 {{/*
@@ -164,7 +168,7 @@ Keeper Host
     {{ .Values.clickhouse.keeper.host }}
   {{- else -}}
     {{- if .Values.keeper.enabled -}}
-      {{- include "clickhouse-keeper.fullname" (dict "Chart" (index .Subcharts "keeper" "Chart") "Release" .Release "Values" (index .Values "keeper")) -}}
+      {{- printf "keeper-%s" (include "clickhouse.fullname" .) | replace "+" "_" | trunc 63 | trimSuffix "-" }}
     {{- else -}}
     {{- end -}}
   {{- end -}}

--- a/charts/clickhouse/templates/chi.yaml
+++ b/charts/clickhouse/templates/chi.yaml
@@ -1,3 +1,4 @@
+{{- $service_name := tpl (include "clickhouse.serviceTemplateName" . ) . -}}
 ---
 apiVersion: "clickhouse.altinity.com/v1"
 kind: ClickHouseInstallation
@@ -8,13 +9,17 @@ metadata:
 spec:
   defaults:
     templates:
-      serviceTemplate: {{ include "clickhouse.serviceTemplateName" . }}
+      serviceTemplate: {{ $service_name }}
+      {{- if .Values.clickhouse.lbService.enabled }}
+      clusterServiceTemplate: {{ $service_name }}-lb
+      {{- end }}
       podTemplate: {{ include "clickhouse.podTemplateName" . }}
       {{- if .Values.clickhouse.persistence.enabled }}
       dataVolumeClaimTemplate: {{ include "clickhouse.volumeClaimTemplateName" . }}
       {{- end }}
   useTemplates:
-    - name: {{ include "clickhouse.serviceTemplateName" . }}
+    - name: {{ $service_name }}
+    - name: {{ $service_name }}-lb
     - name: {{ include "clickhouse.podTemplateName" . }}
     - name: {{ include "clickhouse.volumeClaimTemplateName" . }}
     {{- if not (empty .Values.clickhouse.zones) -}}
@@ -23,7 +28,6 @@ spec:
     - name: {{ include "clickhouse.podTemplateName" $originalContext }}-{{ . }}
     {{- end -}}
     {{- end }}
-
   configuration:
     users:
       default/networks/ip: {{ include "clickhouse.defaultUser.ip" . | quote }}
@@ -53,7 +57,7 @@ spec:
     zookeeper:
         nodes:
           - host: {{ $keeper_host }}
-            port: {{ .Values.keeper.port }}
+            port: {{ .Values.clickhouse.keeper.port }}
     {{- end }}
 
 {{ include "validate.clickhouse.keeper" . }}

--- a/charts/clickhouse/templates/chi.yaml
+++ b/charts/clickhouse/templates/chi.yaml
@@ -19,7 +19,9 @@ spec:
       {{- end }}
   useTemplates:
     - name: {{ $service_name }}
+    {{- if .Values.clickhouse.lbService.enabled }}
     - name: {{ $service_name }}-lb
+    {{- end }}
     - name: {{ include "clickhouse.podTemplateName" . }}
     - name: {{ include "clickhouse.volumeClaimTemplateName" . }}
     {{- if not (empty .Values.clickhouse.zones) -}}

--- a/charts/clickhouse/templates/chit-service.yaml
+++ b/charts/clickhouse/templates/chit-service.yaml
@@ -1,22 +1,26 @@
+{{- $service_name := tpl (include "clickhouse.serviceTemplateName" . ) . -}}
 ---
 apiVersion: "clickhouse.altinity.com/v1"
 kind: ClickHouseInstallationTemplate
 metadata:
-  name: {{ include "clickhouse.serviceTemplateName" . }}
+  name: {{ $service_name }}
   labels:
     {{- include "clickhouse.labels" . | nindent 4 }}
 spec:
   templates:
     serviceTemplates:
-      - name: {{ include "clickhouse.serviceTemplateName" . }}
+      - name: "{{ $service_name }}"
         metadata:
-          {{- with .Values.podAnnotations }}
+          {{- with .Values.clickhouse.service.serviceAnnotations }}
           annotations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           labels:
             {{- include "clickhouse.labels" . | nindent 12 }}
             {{- with .Values.podLabels }}
+            {{- toYaml . | nindent 10 }}
+            {{- end }}
+            {{- with .Values.clickhouse.service.serviceLabels }}
             {{- toYaml . | nindent 10 }}
             {{- end }}
         spec:
@@ -30,3 +34,40 @@ spec:
               targetPort: 9000
           selector:
             {{- include "clickhouse.selectorLabels" . | nindent 12 }}
+{{- if .Values.clickhouse.lbService.enabled }}
+---
+apiVersion: "clickhouse.altinity.com/v1"
+kind: ClickHouseInstallationTemplate
+metadata:
+  name: "{{ $service_name }}-lb"
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+spec:
+  templates:
+    serviceTemplates:
+      - name: "{{ $service_name }}-lb"
+        metadata:
+          labels:
+            {{- include "clickhouse.labels" . | nindent 12 }}
+            {{- with .Values.podLabels }}
+            {{- toYaml . | nindent 10 }}
+            {{- end }}
+            {{- with .Values.clickhouse.lbService.serviceLabels }}
+            {{- toYaml . | nindent 10 }}
+            {{- end }}
+          {{- with .Values.clickhouse.lbService.serviceAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        spec:
+          type: "LoadBalancer"
+          ports:
+            - name: http
+              port: 8123
+              targetPort: 8123
+            - name: tcp
+              port: 9000
+              targetPort: 9000
+          selector:
+            {{- include "clickhouse.selectorLabels" . | nindent 12 }}
+{{- end }}

--- a/charts/clickhouse/templates/chk.yaml
+++ b/charts/clickhouse/templates/chk.yaml
@@ -1,0 +1,132 @@
+{{- if .Values.keeper.enabled }}
+{{- $cluster_name := tpl (include "clickhouse.clustername" . ) . -}}
+{{- $keeper_host := tpl (include "clickhouse.keeper.host" . ) . -}}
+{{- $count := (.Values.keeper.replicaCount | int) -}}
+---
+apiVersion: "clickhouse-keeper.altinity.com/v1"
+kind: "ClickHouseKeeperInstallation"
+metadata:
+  name: {{ include "clickhouse.fullname" . }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+spec:
+  configuration:
+    clusters:
+      - name: "{{ $cluster_name }}"
+        layout:
+          replicas:
+        {{- range $i, $e := until $count }}
+            - name: "keeper-{{ $i }}"
+              templates:
+                podTemplate: "keeper-{{ $i }}"
+                dataVolumeClaimTemplate: "keeper-{{ $i }}"
+                replicaServiceTemplate: "keeper-{{ $i }}"
+        {{- end }}
+    {{- if not (empty .Values.keeper.settings) }}
+    settings:
+    {{- range $k, $v := .Values.keeper.settings }}
+      {{ $k }}: {{ $v }}
+    {{- end }}
+    {{- end }}
+  defaults:
+    storageManagement:
+      provisioner: Operator
+      reclaimPolicy: Retain
+  templates:
+    serviceTemplates:  
+    {{- range $i, $e := until $count }}
+      - name: "keeper-{{ $i }}"
+        generateName: "{{ $keeper_host }}-{{ $i }}"
+        spec:
+          type: ClusterIP
+          publishNotReadyAddresses: true
+          ports:
+            - name: zk
+              port: 2181
+              targetPort: 2181
+            - name: raft
+              port: 9444
+              targetPort: 9444
+            {{- if not (empty $.Values.keeper.metricsPort) }}
+            - name: metrics
+              port: {{ $.Values.keeper.metricsPort }}
+              targetPort: {{ $.Values.keeper.metricsPort }}
+            {{- end }}
+    {{- end }}
+    volumeClaimTemplates: 
+      {{- range $i, $e := until $count }}
+      - name: "keeper-{{ $i }}"
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: {{ $.Values.keeper.localStorage.size }}
+          {{- if $.Values.keeper.localStorage.storageClass }}
+          storageClassName: "{{ $.Values.keeper.localStorage.storageClass }}"
+          {{- end }}
+      {{- end }}
+    podTemplates:
+    {{- range $i, $e := until $count }}
+      - name: "keeper-{{ $i }}"
+        generateName: "{{ $keeper_host }}-{{ $i }}"
+        {{- with $.Values.keeper.podAnnotations }}
+        metadata:
+          annotations:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+        spec:
+          {{- if $.Values.keeper.nodeSelector }}
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      {{- range $k, $v := $.Values.keeper.nodeSelector }}
+                      - key: {{ $k }}
+                        operator: In
+                        values:
+                          - {{ $v }}
+                      {{- end }}
+          {{- end }}
+          topologySpreadConstraints:
+          {{- if $.Values.keeper.zoneSpread }}
+          - maxSkew: 1
+            topologyKey: zone
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                clickhouse-keeper.altinity.com/cluster: "{{ $cluster_name }}"
+          {{- end }}
+          - maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                clickhouse-keeper.altinity.com/cluster: "{{ $cluster_name }}"
+          {{- if $.Values.keeper.tolerations }}
+          tolerations:
+            {{- range $.Values.keeper.tolerations }}
+            - key: "{{ .Key }}"
+              operator: "{{ .Operator }}"
+              value: "{{ .Value }}"
+              effect: "{{ .Effect }}"
+            {{- end }}
+          {{- end }}
+          containers:
+            - name: clickhouse-keeper
+              image: "{{ $.Values.keeper.image }}:{{ $.Values.keeper.tag }}"
+              {{- if not (empty $.Values.keeper.metricsPort) }}
+              ports:
+              - name: metrics
+                containerPort: {{ $.Values.keeper.metricsPort }}
+              {{- end }}
+              resources:
+                requests:
+                  cpu: "{{ $.Values.keeper.resources.cpuRequestsMs }}"
+                  memory: "{{ $.Values.keeper.resources.memoryRequestsMiB }}"
+                limits:
+                  cpu: "{{ $.Values.keeper.resources.cpuLimitsMs }}"
+                  memory: "{{ $.Values.keeper.resources.memoryLimitsMiB }}"
+    {{- end }}
+{{- end }}

--- a/charts/clickhouse/templates/chk.yaml
+++ b/charts/clickhouse/templates/chk.yaml
@@ -92,7 +92,7 @@ spec:
           topologySpreadConstraints:
           {{- if $.Values.keeper.zoneSpread }}
           - maxSkew: 1
-            topologyKey: zone
+            topologyKey: topology.kubernetes.io/zone
             whenUnsatisfiable: ScheduleAnyway
             labelSelector:
               matchLabels:
@@ -104,14 +104,9 @@ spec:
             labelSelector:
               matchLabels:
                 clickhouse-keeper.altinity.com/cluster: "{{ $cluster_name }}"
-          {{- if $.Values.keeper.tolerations }}
+          {{- with $.Values.keeper.tolerations }}
           tolerations:
-            {{- range $.Values.keeper.tolerations }}
-            - key: "{{ .Key }}"
-              operator: "{{ .Operator }}"
-              value: "{{ .Value }}"
-              effect: "{{ .Effect }}"
-            {{- end }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           containers:
             - name: clickhouse-keeper

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -93,7 +93,7 @@ clickhouse:
   affinity: {}
 
   # @ignore
-  topologySpreadConstraints: {}
+  topologySpreadConstraints: []
 
 
 # CHK parameters
@@ -108,7 +108,7 @@ keeper:
   image: "altinity/clickhouse-keeper"
   tag: "24.3.12.76.altinitystable"
   # allows configure multiple aspects and behavior for `clickhouse-keeper` instance
-  settings: []
+  settings: {}
   localStorage:
     size: 5Gi
     storageClass: ""
@@ -119,10 +119,10 @@ keeper:
   zoneSpread: false
   metricsPort: ""
   resources:
-    cpuRequestsMs: "250m"
-    memoryRequestsMiB: "128Mi"
-    cpuLimitsMs: "500m"
-    memoryLimitsMiB: "128Mi"
+    cpuRequestsMs: "2"
+    memoryRequestsMiB: "3Gi"
+    cpuLimitsMs: "3"
+    memoryLimitsMiB: "3Gi"
 
 operator:
   # -- Whether to enabled the Altinity Operator for ClickHouse.

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -55,12 +55,18 @@ clickhouse:
     repository: altinity/clickhouse-server
     pullPolicy: IfNotPresent
     # -- Override the image tag for a specific version
-    tag: "23.8.8.21.altinitystable"
+    tag: "24.3.12.76.altinitystable"
 
   service:
     # e.g. `LoadBalancer`, `NodePort`
     type: ClusterIP
+    serviceAnnotations: {}
+    serviceLabels: {}
 
+  lbService:
+    enable: false
+    serviceAnnotations: {}
+    serviceLabels: {}
 
   # @ignore
   imagePullSecrets: []
@@ -86,8 +92,11 @@ clickhouse:
   # @ignore
   affinity: {}
 
+  # @ignore
+  topologySpreadConstraints: {}
 
-# Subcharts (with aliases) 
+
+# CHK parameters
 keeper:
   # -- Whether to enable Keeper.
   # Required for replicated tables.
@@ -96,6 +105,24 @@ keeper:
   # Must be an odd number.
   # !! DO NOT CHANGE AFTER INITIAL DEPLOYMENT
   replicaCount: 3
+  image: "altinity/clickhouse-keeper"
+  tag: "24.3.12.76.altinitystable"
+  # allows configure multiple aspects and behavior for `clickhouse-keeper` instance
+  settings: []
+  localStorage:
+    size: 5Gi
+    storageClass: ""
+  nodeSelector: {}
+  tolerations: {}
+  podAnnotations: {}
+  # topologySpreadConstraints over `zone`, by deafult there is only podAntiAffinity by hostname 
+  zoneSpread: false
+  metricsPort: ""
+  resources:
+    cpuRequestsMs: "250m"
+    memoryRequestsMiB: "128Mi"
+    cpuLimitsMs: "500m"
+    memoryLimitsMiB: "128Mi"
 
 operator:
   # -- Whether to enabled the Altinity Operator for ClickHouse.


### PR DESCRIPTION
Tested with value file:
```
clickhouse:
  antiAffinity: true
  replicasCount: 3
  lbService:
    enabled: true
    serviceAnnotations:
      minikube.io/lb: "internal"
  nodeSelector:
    node.kubernetes.io/instance-type: "minikube-node"
  persistence:
    enabled: true
    size: 5Gi
  topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: zone
    whenUnsatisfiable: ScheduleAnyway
    labelSelector:
      matchLabels:
        clickhouse-keeper.altinity.com/cluster: chk-test

keeper:
  enabled: true
  replicaCount: 3
  zoneSpread: true
  localStorage:
    size: 1Gi
  metricsPort: 7000
  settings:
    prometheus/endpoint: /metrics
    prometheus/port: 7000
    prometheus/metrics: true
    prometheus/events: true
    prometheus/asynchronous_metrics: true
    prometheus/status_info: true
  podAnnotations:
    prometheus.io/port: "7000"
    prometheus.io/scrape: "true"
```

Rendered to:


```
---
# Source: clickhouse/templates/chi.yaml
apiVersion: "clickhouse.altinity.com/v1"
kind: ClickHouseInstallation
metadata:
  name: chk-test-clickhouse
  labels:
    helm.sh/chart: clickhouse-0.2.0
    app.kubernetes.io/name: clickhouse
    app.kubernetes.io/instance: chk-test
    app.kubernetes.io/version: "24.3.12.76"
    app.kubernetes.io/managed-by: Helm
spec:
  defaults:
    templates:
      serviceTemplate: chk-test-clickhouse-service
      clusterServiceTemplate: chk-test-clickhouse-service-lb
      podTemplate: chk-test-clickhouse-pod
      dataVolumeClaimTemplate: chk-test-clickhouse-data
  useTemplates:
    - name: chk-test-clickhouse-service
    - name: chk-test-clickhouse-service-lb
    - name: chk-test-clickhouse-pod
    - name: chk-test-clickhouse-data
  configuration:
    users:
      default/networks/ip: "127.0.0.1/32"
      default/access_management: 1
      default/password:
        valueFrom:
          secretKeyRef:
            name: chk-test-clickhouse-credentials
            key: password
    clusters:
      - name: chk-test
        layout:
          shardsCount: 1
          replicasCount: 3
    zookeeper:
        nodes:
          - host: keeper-chk-test-clickhouse
            port: 2181
---
# Source: clickhouse/templates/chit-data.yaml
apiVersion: "clickhouse.altinity.com/v1"
kind: ClickHouseInstallationTemplate
metadata:
  name: chk-test-clickhouse-data
  labels:
    helm.sh/chart: clickhouse-0.2.0
    app.kubernetes.io/name: clickhouse
    app.kubernetes.io/instance: chk-test
    app.kubernetes.io/version: "24.3.12.76"
    app.kubernetes.io/managed-by: Helm
spec:
  templates:
    volumeClaimTemplates:
      - name: chk-test-clickhouse-data
        reclaimPolicy: Retain
        spec:
          accessModes:
            - ReadWriteOnce
          resources:
            requests:
              storage: 5Gi
---
# Source: clickhouse/templates/chit-pod.yaml
apiVersion: "clickhouse.altinity.com/v1"
kind: ClickHouseInstallationTemplate
metadata:
  name: chk-test-clickhouse-pod
  labels:
    helm.sh/chart: clickhouse-0.2.0
    app.kubernetes.io/name: clickhouse
    app.kubernetes.io/instance: chk-test
    app.kubernetes.io/version: "24.3.12.76"
    app.kubernetes.io/managed-by: Helm
spec:
  templates:
    podTemplates:
      - name: chk-test-clickhouse-pod

        metadata:
          labels:
            helm.sh/chart: clickhouse-0.2.0
            app.kubernetes.io/name: clickhouse
            app.kubernetes.io/instance: chk-test
            app.kubernetes.io/version: "24.3.12.76"
            app.kubernetes.io/managed-by: Helm
        podDistribution:
          - type: ClickHouseAntiAffinity
            scope: ClickHouseInstallation
        spec:
          securityContext:
            {}
          containers:
            - name: clickhouse
              securityContext:
                {}
              image: "altinity/clickhouse-server:24.3.12.76.altinitystable"
              imagePullPolicy: IfNotPresent
              resources:
                null
          nodeSelector:
            node.kubernetes.io/instance-type: minikube-node
          topologySpreadConstraints:
            - labelSelector:
                matchLabels:
                  clickhouse-keeper.altinity.com/cluster: chk-test
              maxSkew: 1
              topologyKey: zone
              whenUnsatisfiable: ScheduleAnyway
---
# Source: clickhouse/templates/chit-service.yaml
apiVersion: "clickhouse.altinity.com/v1"
kind: ClickHouseInstallationTemplate
metadata:
  name: chk-test-clickhouse-service
  labels:
    helm.sh/chart: clickhouse-0.2.0
    app.kubernetes.io/name: clickhouse
    app.kubernetes.io/instance: chk-test
    app.kubernetes.io/version: "24.3.12.76"
    app.kubernetes.io/managed-by: Helm
spec:
  templates:
    serviceTemplates:
      - name: "chk-test-clickhouse-service"
        metadata:
          labels:
            helm.sh/chart: clickhouse-0.2.0
            app.kubernetes.io/name: clickhouse
            app.kubernetes.io/instance: chk-test
            app.kubernetes.io/version: "24.3.12.76"
            app.kubernetes.io/managed-by: Helm
        spec:
          type: ClusterIP
          ports:
            - name: http
              port: 8123
              targetPort: 8123
            - name: tcp
              port: 9000
              targetPort: 9000
          selector:
            app.kubernetes.io/name: clickhouse
            app.kubernetes.io/instance: chk-test
---
# Source: clickhouse/templates/chit-service.yaml
apiVersion: "clickhouse.altinity.com/v1"
kind: ClickHouseInstallationTemplate
metadata:
  name: "chk-test-clickhouse-service-lb"
  labels:
    helm.sh/chart: clickhouse-0.2.0
    app.kubernetes.io/name: clickhouse
    app.kubernetes.io/instance: chk-test
    app.kubernetes.io/version: "24.3.12.76"
    app.kubernetes.io/managed-by: Helm
spec:
  templates:
    serviceTemplates:
      - name: "chk-test-clickhouse-service-lb"
        metadata:
          labels:
            helm.sh/chart: clickhouse-0.2.0
            app.kubernetes.io/name: clickhouse
            app.kubernetes.io/instance: chk-test
            app.kubernetes.io/version: "24.3.12.76"
            app.kubernetes.io/managed-by: Helm
          annotations:
            minikube.io/lb: internal
        spec:
          type: "LoadBalancer"
          ports:
            - name: http
              port: 8123
              targetPort: 8123
            - name: tcp
              port: 9000
              targetPort: 9000
          selector:
            app.kubernetes.io/name: clickhouse
            app.kubernetes.io/instance: chk-test
---
# Source: clickhouse/templates/chk.yaml
apiVersion: "clickhouse-keeper.altinity.com/v1"
kind: "ClickHouseKeeperInstallation"
metadata:
  name: chk-test-clickhouse
  labels:
    helm.sh/chart: clickhouse-0.2.0
    app.kubernetes.io/name: clickhouse
    app.kubernetes.io/instance: chk-test
    app.kubernetes.io/version: "24.3.12.76"
    app.kubernetes.io/managed-by: Helm
spec:
  configuration:
    clusters:
      - name: "chk-test"
        layout:
          replicas:
            - name: "keeper-0"
              templates:
                podTemplate: "keeper-0"
                dataVolumeClaimTemplate: "keeper-0"
                replicaServiceTemplate: "keeper-0"
            - name: "keeper-1"
              templates:
                podTemplate: "keeper-1"
                dataVolumeClaimTemplate: "keeper-1"
                replicaServiceTemplate: "keeper-1"
            - name: "keeper-2"
              templates:
                podTemplate: "keeper-2"
                dataVolumeClaimTemplate: "keeper-2"
                replicaServiceTemplate: "keeper-2"
    settings:
      prometheus/asynchronous_metrics: true
      prometheus/endpoint: /metrics
      prometheus/events: true
      prometheus/metrics: true
      prometheus/port: 7000
      prometheus/status_info: true
  defaults:
    storageManagement:
      provisioner: Operator
      reclaimPolicy: Retain
  templates:
    serviceTemplates:
      - name: "keeper-0"
        generateName: "keeper-chk-test-clickhouse-0"
        spec:
          type: ClusterIP
          publishNotReadyAddresses: true
          ports:
            - name: zk
              port: 2181
              targetPort: 2181
            - name: raft
              port: 9444
              targetPort: 9444
            - name: metrics
              port: 7000
              targetPort: 7000
      - name: "keeper-1"
        generateName: "keeper-chk-test-clickhouse-1"
        spec:
          type: ClusterIP
          publishNotReadyAddresses: true
          ports:
            - name: zk
              port: 2181
              targetPort: 2181
            - name: raft
              port: 9444
              targetPort: 9444
            - name: metrics
              port: 7000
              targetPort: 7000
      - name: "keeper-2"
        generateName: "keeper-chk-test-clickhouse-2"
        spec:
          type: ClusterIP
          publishNotReadyAddresses: true
          ports:
            - name: zk
              port: 2181
              targetPort: 2181
            - name: raft
              port: 9444
              targetPort: 9444
            - name: metrics
              port: 7000
              targetPort: 7000
    volumeClaimTemplates:
      - name: "keeper-0"
        spec:
          accessModes:
            - ReadWriteOnce
          resources:
            requests:
              storage: 1Gi
      - name: "keeper-1"
        spec:
          accessModes:
            - ReadWriteOnce
          resources:
            requests:
              storage: 1Gi
      - name: "keeper-2"
        spec:
          accessModes:
            - ReadWriteOnce
          resources:
            requests:
              storage: 1Gi
    podTemplates:
      - name: "keeper-0"
        generateName: "keeper-chk-test-clickhouse-0"
        metadata:
          annotations:
            prometheus.io/port: "7000"
            prometheus.io/scrape: "true"
        spec:
          topologySpreadConstraints:
          - maxSkew: 1
            topologyKey: zone
            whenUnsatisfiable: ScheduleAnyway
            labelSelector:
              matchLabels:
                clickhouse-keeper.altinity.com/cluster: "chk-test"
          - maxSkew: 1
            topologyKey: kubernetes.io/hostname
            whenUnsatisfiable: DoNotSchedule
            labelSelector:
              matchLabels:
                clickhouse-keeper.altinity.com/cluster: "chk-test"
          containers:
            - name: clickhouse-keeper
              image: "altinity/clickhouse-keeper:24.3.12.76.altinitystable"
              ports:
              - name: metrics
                containerPort: 7000
              resources:
                requests:
                  cpu: "250m"
                  memory: "128Mi"
                limits:
                  cpu: "500m"
                  memory: "128Mi"
      - name: "keeper-1"
        generateName: "keeper-chk-test-clickhouse-1"
        metadata:
          annotations:
            prometheus.io/port: "7000"
            prometheus.io/scrape: "true"
        spec:
          topologySpreadConstraints:
          - maxSkew: 1
            topologyKey: zone
            whenUnsatisfiable: ScheduleAnyway
            labelSelector:
              matchLabels:
                clickhouse-keeper.altinity.com/cluster: "chk-test"
          - maxSkew: 1
            topologyKey: kubernetes.io/hostname
            whenUnsatisfiable: DoNotSchedule
            labelSelector:
              matchLabels:
                clickhouse-keeper.altinity.com/cluster: "chk-test"
          containers:
            - name: clickhouse-keeper
              image: "altinity/clickhouse-keeper:24.3.12.76.altinitystable"
              ports:
              - name: metrics
                containerPort: 7000
              resources:
                requests:
                  cpu: "250m"
                  memory: "128Mi"
                limits:
                  cpu: "500m"
                  memory: "128Mi"
      - name: "keeper-2"
        generateName: "keeper-chk-test-clickhouse-2"
        metadata:
          annotations:
            prometheus.io/port: "7000"
            prometheus.io/scrape: "true"
        spec:
          topologySpreadConstraints:
          - maxSkew: 1
            topologyKey: zone
            whenUnsatisfiable: ScheduleAnyway
            labelSelector:
              matchLabels:
                clickhouse-keeper.altinity.com/cluster: "chk-test"
          - maxSkew: 1
            topologyKey: kubernetes.io/hostname
            whenUnsatisfiable: DoNotSchedule
            labelSelector:
              matchLabels:
                clickhouse-keeper.altinity.com/cluster: "chk-test"
          containers:
            - name: clickhouse-keeper
              image: "altinity/clickhouse-keeper:24.3.12.76.altinitystable"
              ports:
              - name: metrics
                containerPort: 7000
              resources:
                requests:
                  cpu: "250m"
                  memory: "128Mi"
                limits:
                  cpu: "500m"
                  memory: "128Mi"
```