### PR TITLE
Update docs, stop builds for README updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - main
-
+    paths-ignore:
+      - '**/README.md'
 jobs:
   release:
     permissions:

--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
-# Kubernetes Blueprints for ClickHouse
+# Altinity Helm Charts for ClickHouse®
 
-> Collection of samples to getting started with ClickHouse and ClickHouse Keeper
+> Helm charts for getting started with ClickHouse® and ClickHouse Keeper.
 
 These samples demonstrate straightforward Helm charts that can be used to deploy ClickHouse and ClickHouse Keeper. The examples are intended as starting points for more complex configurations and do not cover all possible uses cases.
 
-**⚠️ Important notes:**
-
-1. ClickHouse Keeper resources (CHK) are not stable yet and should not be used in production environments.
-2. Connections are unencrypted. Avoid using them for sensitive data.
-3. Selecting the external `LoadBalancer` service type in `values.yaml` will expose one or more ports to the Internet, which can pose security risks.
+For more complex configurations, consider applying your own `ClickHouseInstallation` and `ClickHouseKeeperInstallation` resources. The [cluster settings documentation](https://docs.altinity.com/altinitykubernetesoperator/kubernetesoperatorguide/kubernetesconfigurationguide/clustersettings/) is a good starting point.
 
 ## Prerequisites
 
@@ -30,8 +26,15 @@ helm install clickhouse-operator clickhouse-operator/altinity-clickhouse-operato
 
 ## Helm Charts
 
-- **[clickhouse](./charts/clickhouse/)**: Deploys a ClickHouse cluster with dependencies.
+- **[clickhouse](./charts/clickhouse/)**: All-in-one chart to deploy a ClickHouse cluster (and optionally Keeper and the Altinity Operator)
+- **[clickhouse](./charts/clickhouse-eks/)**: An EKS-specific chart for high-availability ClickHouse clusters. 
+
+### Deprecated Charts
+
+Since [Release 0.24.0](https://docs.altinity.com/releasenotes/altinity-kubernetes-operator-release-notes/#release-0240) keeper can be managed with a custom resource. These charts are deprecated and may not receive further updates:
+
 - **[clickhouse-keeper-sts](./charts/clickhouse-keeper-sts/)**: Deploys ClickHouse Keeper using StatefulSets for better data persistence.
+- **[keeper-sts](./charts/clickhouse-keeper-sts/)**: Deploys ClickHouse Keeper using StatefulSets for better data persistence.
 
 ### How to Install a Chart
 
@@ -52,7 +55,7 @@ There are several [examples](./charts/clickhouse/examples) available. You can us
 
 
 ```sh
-helm install release-name --namespace clickhouse --create-namespace -f path/to/examples/values-simple.yaml 
+helm install release-name --namespace clickhouse --create-namespace -f path/to/examples/values-simple.yaml altinity/clickhouse
 ```
 
 > Please refer to any of helm charts `README` file for detailed instructions about each of the them.
@@ -62,4 +65,4 @@ We welcome contributions from the community! If you encounter issues or have imp
 
 ## Legal
 All code, unless specified otherwise, is licensed under the [Apache-2.0](LICENSE) license.
-Copyright (c) 2024 Altinity, Inc.
+Copyright (c) 2025 Altinity, Inc.

--- a/charts/clickhouse-eks/README.md
+++ b/charts/clickhouse-eks/README.md
@@ -2,7 +2,7 @@
 
 # clickhouse-eks
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 A Helm chart for ClickHouse running on AWS EKS across AZs using a nodeSelector to pin resources to run on specific VMs types
 
@@ -10,10 +10,10 @@ A Helm chart for ClickHouse running on AWS EKS across AZs using a nodeSelector t
 
 ```sh
 # add the kubernetes-blueprints-for-clickhouse chart repository
-helm repo add kubernetes-blueprints-for-clickhouse https://altinity.github.io/kubernetes-blueprints-for-clickhouse
+helm repo add altinity https://helm.altinity.com
 
 # use this command to install clickhouse-eks chart (it will also create a `clickhouse` namespace)
-helm install ch kubernetes-blueprints-for-clickhouse/clickhouse-eks --namespace clickhouse --create-namespace
+helm install ch altinity/clickhouse-eks --namespace clickhouse --create-namespace
 ```
 
 > Use `-f` flag to override default values: `helm install -f newvalues.yaml`
@@ -54,7 +54,7 @@ kubectl exec -it chi-eks-dev-0-0-0 --namespace clickhouse -- clickhouse-client
 |-----|------|---------|-------------|
 | all.metadata.labels.application_group | string | `"eks"` | The name of the application group |
 | clickhouse.cluster | string | `"dev"` | Cluster name |
-| clickhouse.image | string | `"altinity/clickhouse-server:23.8.8.21.altinitystable"` | ClickHouse server image |
+| clickhouse.image | string | `"altinity/clickhouse-server:24.3.12.76.altinitystable"` | ClickHouse server image |
 | clickhouse.keeper_name | string | `"keeper-eks"` | Name of the keeper cluster |
 | clickhouse.name | string | `"eks"` | Metadata name |
 | clickhouse.node_selector | string | `"m6i.large"` | AWS instance type |

--- a/charts/clickhouse-keeper-sts/README.md
+++ b/charts/clickhouse-keeper-sts/README.md
@@ -4,37 +4,9 @@
 
 ![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 24.3.6.48](https://img.shields.io/badge/AppVersion-24.3.6.48-informational?style=flat-square)
 
-A ClickHouse Keeper chart for Kubernetes
+A ClickHouse® Keeper chart for Kubernetes
 
-## Installing the Chart
-
-```sh
-# add the kubernetes-blueprints-for-clickhouse chart repository
-helm repo add kubernetes-blueprints-for-clickhouse https://altinity.github.io/kubernetes-blueprints-for-clickhouse
-
-# use this command to install clickhouse-keeper-sts chart (it will also create a `clickhouse` namespace)
-helm install ch kubernetes-blueprints-for-clickhouse/clickhouse-keeper-sts --namespace clickhouse --create-namespace
-```
-
-> Use `-f` flag to override default values: `helm install -f newvalues.yaml`
-
-## Upgrading the Chart
-```sh
-# get latest repository versions
-helm repo update
-
-# upgrade to a newer version using the release name (`ch`)
-helm upgrade ch kubernetes-blueprints-for-clickhouse/clickhouse-keeper-sts --namespace clickhouse
-```
-
-## Uninstalling the Chart
-
-```sh
-# uninstall using the release name (`ch`)
-helm uninstall ch --namespace clickhouse
-```
-
-> This command removes all the Kubernetes components associated with the chart and deletes the release.
+Since [Release 0.24.0](https://docs.altinity.com/releasenotes/altinity-kubernetes-operator-release-notes/#release-0240) keeper can be managed with a custom resource. **This chart is deprecated** and may not receive further updates:
 
 ## Connecting to your ClickHouse Cluster
 

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -2,9 +2,9 @@
 
 # clickhouse
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 23.8.8.21](https://img.shields.io/badge/AppVersion-23.8.8.21-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 24.3.12.76](https://img.shields.io/badge/AppVersion-24.3.12.76-informational?style=flat-square)
 
-A Helm chart for creating a ClickHouse Cluster with the Altinity Operator for ClickHouse
+A Helm chart for creating a ClickHouse® Cluster with the Altinity Operator for ClickHouse
 
 ## Requirements
 
@@ -16,19 +16,28 @@ A Helm chart for creating a ClickHouse Cluster with the Altinity Operator for Cl
 
 ```sh
 # add the kubernetes-blueprints-for-clickhouse chart repository
-helm repo add altinity https://helm.altinity.com
+helm repo add kubernetes-blueprints-for-clickhouse https://altinity.github.io/kubernetes-blueprints-for-clickhouse
 
 # use this command to install clickhouse chart (it will also create a `clickhouse` namespace)
-helm install clickhouse-dev --create-namespace --namespace clickhouse altinity/clickhouse  --set keeper.enabled=true --set clickhouse.replicasCount=2
+helm install ch kubernetes-blueprints-for-clickhouse/clickhouse --namespace clickhouse --create-namespace
 ```
 
 > Use `-f` flag to override default values: `helm install -f newvalues.yaml`
+
+## Upgrading the Chart
+```sh
+# get latest repository versions
+helm repo update
+
+# upgrade to a newer version using the release name (`ch`)
+helm upgrade ch kubernetes-blueprints-for-clickhouse/clickhouse --namespace clickhouse
+```
 
 ## Uninstalling the Chart
 
 ```sh
 # uninstall using the release name (`ch`)
-helm uninstall clickhouse-dev --namespace clickhouse
+helm uninstall ch --namespace clickhouse
 ```
 
 > This command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -59,6 +68,9 @@ kubectl exec -it chi-eks-dev-0-0-0 --namespace clickhouse -- clickhouse-client
 | clickhouse.keeper | object | `{"host":"","port":2181}` | Keeper connection settings for ClickHouse instances. |
 | clickhouse.keeper.host | string | `""` | Specify a keeper host. Should be left empty if `clickhouse-keeper.enabled` is `true`. Will override the defaults set from `clickhouse-keeper.enabled`. |
 | clickhouse.keeper.port | int | `2181` | Override the default keeper port |
+| clickhouse.lbService.enable | bool | `false` |  |
+| clickhouse.lbService.serviceAnnotations | object | `{}` |  |
+| clickhouse.lbService.serviceLabels | object | `{}` |  |
 | clickhouse.persistence.accessMode | string | `"ReadWriteOnce"` |  |
 | clickhouse.persistence.enabled | bool | `true` | enable storage |
 | clickhouse.persistence.logs.accessMode | string | `"ReadWriteOnce"` |  |
@@ -69,23 +81,24 @@ kubectl exec -it chi-eks-dev-0-0-0 --namespace clickhouse -- clickhouse-client
 | clickhouse.podAnnotations | object | `{}` |  |
 | clickhouse.podLabels | object | `{}` |  |
 | clickhouse.replicasCount | int | `1` | number of replicas. If greater than 1, keeper must be enabled or a keeper host should be provided under clickhouse.keeper.host.  Will be ignored if `zones` is set. |
+| clickhouse.service.serviceAnnotations | object | `{}` |  |
+| clickhouse.service.serviceLabels | object | `{}` |  |
 | clickhouse.service.type | string | `"ClusterIP"` |  |
-| clickhouse.service.lbService.enable | bool | `false` | additional cluster LB service |
-| clickhouse.service.lbService.serviceAnnotations | object | `""` | annotations for the LB service |
 | clickhouse.zones | list | `[]` |  |
 | keeper.enabled | bool | `false` | Whether to enable Keeper. Required for replicated tables. |
-| keeper.replicaCount | int | `3` | Number of keeper replicas. Must be an odd number. !! DO NOT CHANGE AFTER INITIAL DEPLOYMENT |
 | keeper.image | string | `"altinity/clickhouse-keeper"` |  |
-| keeper.tag | string | `"24.3.12.76.altinitystable"` |  |
-| keeper.settings | object | `[]` | `clickhouse-keeper` global config, for example: `prometheus/port: "7000"` |
-| keeper.localStorage.size | string | `"5Gi"` | size for keeper PV |
-| keeper.localStorage.storageClass | string | `""` | storage class for keeper PV |
+| keeper.localStorage.size | string | `"5Gi"` |  |
+| keeper.localStorage.storageClass | string | `""` |  |
+| keeper.metricsPort | string | `""` |  |
 | keeper.nodeSelector | object | `{}` |  |
+| keeper.podAnnotations | object | `{}` |  |
+| keeper.replicaCount | int | `3` | Number of keeper replicas. Must be an odd number. !! DO NOT CHANGE AFTER INITIAL DEPLOYMENT |
+| keeper.resources.cpuLimitsMs | string | `"3"` |  |
+| keeper.resources.cpuRequestsMs | string | `"2"` |  |
+| keeper.resources.memoryLimitsMiB | string | `"3Gi"` |  |
+| keeper.resources.memoryRequestsMiB | string | `"3Gi"` |  |
+| keeper.settings | object | `{}` |  |
+| keeper.tag | string | `"24.3.12.76.altinitystable"` |  |
 | keeper.tolerations | object | `{}` |  |
-| keeper.zoneSpread | bool | `false` | topologySpreadConstraints over `zone`, by deafult there is only podAntiAffinity by hostname |
-| keeper.metricsPort | string | `""` | add metrics port to the service and pod |
-| keeper.resources.cpuRequestsMs | string | `"250m"` |  |
-| keeper.resources.memoryRequestsMiB | string | `"128Mi"` |  |
-| keeper.resources.cpuLimitsMs | string | `"500m"` |  |
-| keeper.resources.memoryLimitsMiB | string | `"128Mi"` |  |
+| keeper.zoneSpread | bool | `false` |  |
 | operator.enabled | bool | `true` | Whether to enabled the Altinity Operator for ClickHouse. Disable if you already have the Operator installed cluster-wide. |

--- a/charts/keeper-sts/README.md
+++ b/charts/keeper-sts/README.md
@@ -6,47 +6,7 @@
 
 A Helm chart for setting up ClickHouse Keeper using StatefulSet
 
-## Installing the Chart
-
-```sh
-# add the kubernetes-blueprints-for-clickhouse chart repository
-helm repo add kubernetes-blueprints-for-clickhouse https://altinity.github.io/kubernetes-blueprints-for-clickhouse
-
-# use this command to install keeper-sts chart (it will also create a `clickhouse` namespace)
-helm install ch kubernetes-blueprints-for-clickhouse/keeper-sts --namespace clickhouse --create-namespace
-```
-
-> Use `-f` flag to override default values: `helm install -f newvalues.yaml`
-
-## Upgrading the Chart
-```sh
-# get latest repository versions
-helm repo update
-
-# upgrade to a newer version using the release name (`ch`)
-helm upgrade ch kubernetes-blueprints-for-clickhouse/keeper-sts --namespace clickhouse
-```
-
-## Uninstalling the Chart
-
-```sh
-# uninstall using the release name (`ch`)
-helm uninstall ch --namespace clickhouse
-```
-
-> This command removes all the Kubernetes components associated with the chart and deletes the release.
-
-## Connecting to your ClickHouse Cluster
-
-```sh
-# list your pods
-kubectl get pods --namespace clickhouse
-
-# pick any of your available pods and connect through the clickhouse-client
-kubectl exec -it chi-eks-dev-0-0-0 --namespace clickhouse -- clickhouse-client
-```
-
-> Use `kubectl port forward` to access your ClickHouse cluster from outside: `kubectl port-forward service clickhouse-eks 9000:9000 & clickhouse-client`
+Since [Release 0.24.0](https://docs.altinity.com/releasenotes/altinity-kubernetes-operator-release-notes/#release-0240) keeper can be managed with a custom resource. This chart is deprecated and may not receive further updates:
 
 ## Values
 


### PR DESCRIPTION
- Updates documentation to reflect the deprecation of the pre 0.24.0 CHK charts.
- Updates github actions to not run chart release when only a README file is modified.

  Versions will need to be bumped once to get this to build properly, but after that we will be able to update docs without triggering a build action.