### PR TITLE
fix: repo and chart name in readme

### DIFF
--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -15,11 +15,11 @@ A Helm chart for creating a ClickHouse® Cluster with the Altinity Operator for 
 ## Installing the Chart
 
 ```sh
-# add the kubernetes-blueprints-for-clickhouse chart repository
-helm repo add kubernetes-blueprints-for-clickhouse https://altinity.github.io/kubernetes-blueprints-for-clickhouse
+# add the altinity chart repository
+helm repo add altinity https://helm.altinity.com
 
 # use this command to install clickhouse chart (it will also create a `clickhouse` namespace)
-helm install ch kubernetes-blueprints-for-clickhouse/clickhouse --namespace clickhouse --create-namespace
+helm install release-name altinity/clickhouse --namespace clickhouse --create-namespace
 ```
 
 > Use `-f` flag to override default values: `helm install -f newvalues.yaml`


### PR DESCRIPTION
This pull request includes an update to the `charts/clickhouse/README.md` file to reflect changes in the Helm chart repository and installation instructions.

Documentation updates:

* [`charts/clickhouse/README.md`](diffhunk://#diff-1880a25e5e44df88e5dedac2b3ad771c32ad028811996cd0011710b3f2409b4fL18-R22): Updated the repository URL from `kubernetes-blueprints-for-clickhouse` to `altinity` and modified the Helm install command to use `release-name` instead of `ch`.