### PR TITLE
Fix/extraconfig

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for creating a ClickHouse® Cluster with the Altinity Operator for ClickHouse
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: "24.3.12.76"
 
 dependencies:

--- a/charts/clickhouse/templates/_helpers.tpl
+++ b/charts/clickhouse/templates/_helpers.tpl
@@ -178,8 +178,8 @@ Keeper Host
 Extra Config
 */}}
 {{- define "clickhouse.extra_config" -}}
-  {{- if not (empty .Values.extra_config) -}}
-    {{ .Values.extra_config }}
+  {{- if not (empty .Values.clickhouse.extraConfig) -}}
+    {{ .Values.clickhouse.extraConfig }}
   {{- else -}}
   {{- end -}}
 {{- end -}}

--- a/charts/clickhouse/values.schema.json
+++ b/charts/clickhouse/values.schema.json
@@ -200,7 +200,7 @@
             "type": "object"
           }
         },
-        "extra_config": {
+        "extraConfig": {
           "type": "string",
           "description": "Additional XML config for ClickHouse."
         }

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -100,7 +100,7 @@ clickhouse:
   topologySpreadConstraints: []
 
   # -- Miscellanous config for ClickHouse (in xml format)
-  extra_config: |
+  extraConfig: |
     <clickhouse>
     </clickhouse>
 


### PR DESCRIPTION
Fixes extra_config option to use correct value, renames value to `extraConfig` to follow helm spec 

(since this wasn't working previously, no backwards compatibility issues with the rename)