### PR TITLE
fix tolerations default value type

### DIFF
--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -122,7 +122,7 @@ keeper:
     size: 5Gi
     storageClass: ""
   nodeSelector: {}
-  tolerations: {}
+  tolerations: []
   podAnnotations: {}
   # topologySpreadConstraints over `zone`, by deafult there is only
   # podAntiAffinity by hostname


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/08a65b9b-7bef-453c-830b-400d9ceb626d)

The keeper expects an empty list [] for tolerations, but it’s receiving an object {} in the values. This causes an error when trying to use a non-dedicated node.

For now, I resolved the issue by explicitly setting `tolerations: []`, but since I noticed it, I’ve gone ahead and submitted a PR as well.