### PR TITLE
basic support for configuring users with helm

### DIFF
--- a/charts/clickhouse/templates/chi.yaml
+++ b/charts/clickhouse/templates/chi.yaml
@@ -129,6 +129,25 @@ spec:
           secretKeyRef:
             name: {{ include "clickhouse.credentialsName" . }}
             key: password
+      {{- range .Values.clickhouse.users }}
+      {{ required "A user must have a name" .name }}/access_management: {{ .accessManagement | default 0}}
+      {{ .name }}/networks/ip: {{ .hostIP | default "0.0.0.0/0" | quote }}
+      {{- if .grants }}
+      {{ .name }}/grants/query:
+      {{- range .grants }}
+      - {{ . | quote}}
+      {{- end }}
+      {{- end }}
+      {{- if .password_secret_name }}
+      {{ .name }}/password:
+        valueFrom:
+          secretKeyRef:
+            name: {{ .password_secret_name | quote }}
+            key: password
+      {{- else if .password_sha256_hex }}
+      {{ .name }}/password_sha256_hex: {{ .password_sha256_hex | quote }}
+      {{- end }}
+      {{- end }}
     clusters:
       - name: {{ include "clickhouse.clustername" . }}
         {{- if .Values.clickhouse.clusterSecret.enabled }}
@@ -172,7 +191,7 @@ spec:
     {{- $extraConfig := tpl (include "clickhouse.extraConfig" . ) . -}}
     {{- if not (empty $extraConfig) }}
     files:
-        config.d/extra_config.xml: | 
+        config.d/extra_config.xml: |
           {{- tpl $extraConfig . | nindent 10 }}
     {{- end }}
 

--- a/charts/clickhouse/values.schema.json
+++ b/charts/clickhouse/values.schema.json
@@ -31,6 +31,44 @@
             }
           }
         },
+        "users": {
+          "type": "array",
+          "description": "Users to initialize in ClickHouse",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name for the user",
+                "pattern": "^[a-zA-Z0-9]+$"
+              },
+              "hostIP": {
+                "type": "string",
+                "description": "Mask for IPs allowed for this user.",
+                "default": "0.0.0.0/0"
+              },
+              "password_secret_name": {
+                "type": "string",
+                "description": "Name of a Kubernetes secret containing the plaintext password"
+              },
+              "password_sha256_hex": {
+                "type": "string",
+                "description": "SHA256 of the password (ignored if password_secret_name is passed)"
+              },
+              "grants": {
+                "type": "array",
+                "description": "List of grants to provide for the user",
+                "items": {
+                  "type": "string",
+                  "examples": [
+                    "GRANT SELECT ON default.*",
+                    "GRANT SELECT, DELETE ON foo.bar"
+                  ]
+                }
+              }
+            }
+          }
+        },
         "replicasCount": {
           "type": "integer",
           "description": "Number of ClickHouse replicas. If greater than 1, Keeper must be enabled or a Keeper host must be provided.",

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -16,6 +16,9 @@ clickhouse:
     # @default -- 127.0.0.1/32
     hostIP: 127.0.0.1/32
 
+  # Configure additional users
+  users: []
+
   # -- number of replicas. If greater than 1, keeper must be enabled
   # or a keeper host should be provided under clickhouse.keeper.host.
   # Will be ignored if `zones` is set.


### PR DESCRIPTION
#45 was bumming me out, so I took a stab at it.

This implements basic support for defining additional users. It does not support defining `quotas` or `profiles`.