### PR TITLE
fix chi service and lbService

### DIFF
--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -177,7 +177,7 @@ EOSQL
 | clickhouse.keeper | object | `{"host":"","port":2181}` | Keeper connection settings for ClickHouse instances. |
 | clickhouse.keeper.host | string | `""` | Specify a keeper host. Should be left empty if `clickhouse-keeper.enabled` is `true`. Will override the defaults set from `clickhouse-keeper.enabled`. |
 | clickhouse.keeper.port | int | `2181` | Override the default keeper port |
-| clickhouse.lbService.enable | bool | `false` |  |
+| clickhouse.lbService.enabled | bool | `false` |  |
 | clickhouse.lbService.serviceAnnotations | object | `{}` |  |
 | clickhouse.lbService.serviceLabels | object | `{}` |  |
 | clickhouse.persistence.accessMode | string | `"ReadWriteOnce"` |  |

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -178,6 +178,7 @@ EOSQL
 | clickhouse.keeper.host | string | `""` | Specify a keeper host. Should be left empty if `clickhouse-keeper.enabled` is `true`. Will override the defaults set from `clickhouse-keeper.enabled`. |
 | clickhouse.keeper.port | int | `2181` | Override the default keeper port |
 | clickhouse.lbService.enabled | bool | `false` |  |
+| clickhouse.lbService.loadBalancerSourceRanges | list | `[]` | Source IP CIDR ranges to restrict client IPs. (support dependent on cloud-provider) |
 | clickhouse.lbService.serviceAnnotations | object | `{}` |  |
 | clickhouse.lbService.serviceLabels | object | `{}` |  |
 | clickhouse.persistence.accessMode | string | `"ReadWriteOnce"` |  |

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -214,5 +214,6 @@ EOSQL
 | keeper.settings | object | `{}` |  |
 | keeper.tag | string | `"25.3.6.10034.altinitystable"` |  |
 | keeper.tolerations | list | `[]` |  |
+| keeper.volumeClaimAnnotations | object | `{}` |  |
 | keeper.zoneSpread | bool | `false` |  |
 | operator.enabled | bool | `true` | Whether to enabled the Altinity Operator for ClickHouse. Disable if you already have the Operator installed cluster-wide. |

--- a/charts/clickhouse/templates/chi.yaml
+++ b/charts/clickhouse/templates/chi.yaml
@@ -71,6 +71,10 @@ spec:
           {{- end }}
         spec:
           type: "LoadBalancer"
+          {{- if .Values.clickhouse.lbService.loadBalancerSourceRanges }}
+          loadBalancerSourceRanges:
+            {{- toYaml .Values.clickhouse.lbService.loadBalancerSourceRanges | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               port: 8123

--- a/charts/clickhouse/templates/chi.yaml
+++ b/charts/clickhouse/templates/chi.yaml
@@ -44,7 +44,7 @@ spec:
           labels:
             {{- include "clickhouse.labels" . | nindent 12 }}
             {{- with .Values.clickhouse.service.serviceLabels }}
-            {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
         spec:
           type: {{ .Values.clickhouse.service.type }}
@@ -62,11 +62,8 @@ spec:
         metadata:
           labels:
             {{- include "clickhouse.labels" . | nindent 12 }}
-            {{- with .Values.podLabels }}
-            {{- toYaml . | nindent 10 }}
-            {{- end }}
             {{- with .Values.clickhouse.lbService.serviceLabels }}
-            {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- with .Values.clickhouse.lbService.serviceAnnotations }}
           annotations:

--- a/charts/clickhouse/templates/chk.yaml
+++ b/charts/clickhouse/templates/chk.yaml
@@ -56,6 +56,11 @@ spec:
     volumeClaimTemplates: 
       {{- range $i, $e := until $count }}
       - name: "keeper-{{ $i }}"
+        {{- with $.Values.keeper.volumeClaimAnnotations }}
+        metadata:
+          annotations:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
         spec:
           accessModes:
             - ReadWriteOnce

--- a/charts/clickhouse/values.schema.json
+++ b/charts/clickhouse/values.schema.json
@@ -285,6 +285,10 @@
           "type": "object",
           "description": "Annotations for Keeper pods."
         },
+        "volumeClaimAnnotations": {
+          "type": "object",
+          "description": "Annotations for Keeper volume claims."
+        },
         "zoneSpread": {
           "type": "boolean",
           "description": "Enable topology spread constraints over zone for Keeper."

--- a/charts/clickhouse/values.schema.json
+++ b/charts/clickhouse/values.schema.json
@@ -145,6 +145,13 @@
               "type": "boolean",
               "description": "Enable LoadBalancer service for ClickHouse."
             },
+            "loadBalancerSourceRanges": {
+              "type": "array",
+              "description": "Restricts traffic to specified client IPs.",
+              "items": {
+                "type": "string"
+              }
+            },
             "serviceAnnotations": {
               "type": "object",
               "description": "Annotations for LoadBalancer service."

--- a/charts/clickhouse/values.schema.json
+++ b/charts/clickhouse/values.schema.json
@@ -141,7 +141,7 @@
         "lbService": {
           "type": "object",
           "properties": {
-            "enable": {
+            "enabled": {
               "type": "boolean",
               "description": "Enable LoadBalancer service for ClickHouse."
             },

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -85,6 +85,10 @@ clickhouse:
 
   lbService:
     enabled: false
+    # -- Specify source IP ranges to the LoadBalancer service.
+    # If supported by the platform, this will restrict traffic through the cloud-provider load-balancer
+    # to the specified client IPs. This is ignored if the cloud-provider does not support the feature.
+    loadBalancerSourceRanges: []
     serviceAnnotations: {}
     serviceLabels: {}
 

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -84,7 +84,7 @@ clickhouse:
     serviceLabels: {}
 
   lbService:
-    enable: false
+    enabled: false
     serviceAnnotations: {}
     serviceLabels: {}
 

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -162,6 +162,7 @@ keeper:
   nodeSelector: {}
   tolerations: []
   podAnnotations: {}
+  volumeClaimAnnotations: {}
   # topologySpreadConstraints over `zone`, by deafult there is only
   # podAntiAffinity by hostname
   zoneSpread: false


### PR DESCRIPTION
Hit a couple of issues, mostly around labeling of the Kubernetes Service resources, but also with enabling the load balancer. This PR attempts to fix the issues I ran into.

## Bugfix: enabling and adding labels to the load-balancer

### Expected
1. `clickhouse.service.serviceLabels` and `clickhouse.lbService.serviceLabels` will add labels with correct nesting under their respective `.metadata.labels` block.
2. `clickhouse.lbService.enable`, the documented value, enables the load-balancer service.

### Actual
1. The template incorrectly indents the `*.serviceLabels` blocks, causing the labels to be added directly under the `.metadata` block.
2. The template actually expects the value to be `clickhouse.lbService.enabled` ('enable**d**').

### Reproduction steps
* `Chart.yaml`
    ```yaml
    apiVersion: v2
    name: clickhouse
    version: &clickhouse_version 0.3.1
    dependencies:
      - name: clickhouse
        version: *clickhouse_version
        repository: https://helm.altinity.com
        alias: altinity-clickhouse
    ```
* `values.yaml`
    ```yaml
    altinity-clickhouse:
      fullnameOverride: clickhouse
      operator:
        enabled: false
      keeper:
        enabled: true
      clickhouse:
        replicasCount: 3
        podLabels:
          env: &env staging
          team: &team infrastructure 
          application: &app clickhouse-instance
          criticality: medium
          sla_tier: tier2
          alert_priority: medium
        service:
          serviceLabels:
            env: *env
            team: *team
            application: *app
        lbService:
          enabled: true
          serviceLabels:
            env: *env
            team: *team
            application: chi-load-balancer
    ```
1. Before PR:
   ```sh
    $ helm template chi-local ./ -f ./values.yaml | grep -A 10 -F -- 'name: "clickhouse-service' 
    #       - name: "clickhouse-service"
    #         metadata:
    #           labels:
    #             helm.sh/chart: altinity-clickhouse-0.3.1
    #             app.kubernetes.io/name: altinity-clickhouse
    #             app.kubernetes.io/instance: chi-local
    #             app.kubernetes.io/version: "25.3.6.10034"
    #             app.kubernetes.io/managed-by: Helm
    #           application: clickhouse-instance
    #           env: staging
    #           team: infrastructure
    # --
    #       - name: "clickhouse-service-lb"
    #         metadata:
    #           labels:
    #             helm.sh/chart: altinity-clickhouse-0.3.1
    #             app.kubernetes.io/name: altinity-clickhouse
    #             app.kubernetes.io/instance: chi-local
    #             app.kubernetes.io/version: "25.3.6.10034"
    #             app.kubernetes.io/managed-by: Helm
    #           application: chi-load-balancer
    #           env: staging
    #           team: infrastructure
    ```
3. After this PR:
    ```sh
    $ helm template chi-local ./ -f ./values.yaml | grep -A 10 -F -- 'name: "clickhouse-service'
    #       - name: "clickhouse-service"
    #         metadata:
    #           labels:
    #             helm.sh/chart: altinity-clickhouse-0.3.1
    #             app.kubernetes.io/name: altinity-clickhouse
    #             app.kubernetes.io/instance: chi-local
    #             app.kubernetes.io/version: "25.3.6.10034"
    #             app.kubernetes.io/managed-by: Helm
    #             application: clickhouse-instance
    #             env: staging
    #             team: infrastructure
    # --
    #       - name: "clickhouse-service-lb"
    #         metadata:
    #           labels:
    #             helm.sh/chart: altinity-clickhouse-0.3.1
    #             app.kubernetes.io/name: altinity-clickhouse
    #             app.kubernetes.io/instance: chi-local
    #             app.kubernetes.io/version: "25.3.6.10034"
    #             app.kubernetes.io/managed-by: Helm
    #             application: chi-load-balancer
    #             env: staging
    #             team: infrastructure
    ```

## Other improvements

### Chart value for `loadBalancerSourceRanges`

`clickhouse.lbService.loadBalancerSourceRanges` implements [`loadBalancerSourceRanges`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#:~:text=loadBalancerSourceRanges) for the optional load-balancer Service.

### Chart value to add annotations on the Keeper PVCs

ArgoCD seems to not be able to associate the Keeper PVCs to the Keeper StatefulSet/Pods, causing it to appear as extraneous resources that ArgoCD will delete. Supporting annotations on the Keeper PVC resources so that end-users can optionally set [`argocd.argoproj.io/compare-options: IgnoreExtraneous`](https://argo-cd.readthedocs.io/en/stable/user-guide/compare-options/#ignoring-resources-that-are-extraneous) seems to be the easiest workaround.

Tested successfully:
```yml
    ...
    volumeClaimTemplates:
      - name: "keeper-0"
        metadata:
          annotations:
            argocd.argoproj.io/compare-options: IgnoreExtraneous
        spec:
          accessModes:
            - ReadWriteOnce
          resources:
            requests:
              storage: 5Gi
      - name: "keeper-1"
        metadata:
          annotations:
            argocd.argoproj.io/compare-options: IgnoreExtraneous
        spec:
          accessModes:
            - ReadWriteOnce
          resources:
            requests:
              storage: 5Gi
      - name: "keeper-2"
        metadata:
          annotations:
            argocd.argoproj.io/compare-options: IgnoreExtraneous
        spec:
          accessModes:
            - ReadWriteOnce
          resources:
            requests:
              storage: 5Gi
    podTemplates:
    ...
```

See in-line code comments for more details.