### PR TITLE
extraUsers configuration

### DIFF
--- a/charts/clickhouse/templates/chi.yaml
+++ b/charts/clickhouse/templates/chi.yaml
@@ -195,5 +195,11 @@ spec:
         config.d/extra_config.xml: |
           {{- tpl $extraConfig . | nindent 10 }}
     {{- end }}
+    {{- $extraUsers := tpl (include "clickhouse.extraUsers" . ) . -}}
+    {{- if not (empty $extraUsers) }}
+    files:
+        users.d/extra_users.xml: |
+          {{- tpl $extraUsers . | nindent 10 }}
+    {{- end }}
 
 {{ include "validate.clickhouse.keeper" . }}

--- a/charts/clickhouse/values.schema.json
+++ b/charts/clickhouse/values.schema.json
@@ -249,6 +249,10 @@
           "type": "string",
           "description": "Miscellaneous config for ClickHouse in XML format."
         },
+        "extraUsers": {
+          "type": "string",
+          "description": "Miscellaneous users config for ClickHouse in XML format."
+        },
         "initScripts": {
           "type": "object",
           "description": "Configuration for init scripts via ConfigMap.",

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -134,6 +134,10 @@ clickhouse:
   extraConfig: |
     <clickhouse>
     </clickhouse>
+  # -- Additional users config for ClickHouse (in xml format)
+  extraUsers: |
+    <clickhouse>
+    </clickhouse>
 
   # -- Init scripts ConfigMap configuration
   initScripts:


### PR DESCRIPTION
This is an addition to extraConfig, so we can push extra users.d settings. This will provide some workaround meanwhile we tackle #58

This PR should be simple enough to merge.