### PR TITLE
Add missing template definition for extraUsers

### DIFF
--- a/charts/clickhouse/templates/_helpers.tpl
+++ b/charts/clickhouse/templates/_helpers.tpl
@@ -203,6 +203,15 @@ Extra Config
   {{- end -}}
 {{- end -}}
 {{/*
+Extra Users
+*/}}
+{{- define "clickhouse.extraUsers" -}}
+  {{- if not (empty .Values.clickhouse.extraUsers) -}}
+    {{ .Values.clickhouse.extraUsers }}
+  {{- else -}}
+  {{- end -}}
+{{- end -}}
+{{/*
 Common labels
 */}}
 {{- define "clickhouse.labels" -}}

--- a/charts/clickhouse/templates/chi.yaml
+++ b/charts/clickhouse/templates/chi.yaml
@@ -190,16 +190,17 @@ spec:
             port: {{ .Values.clickhouse.keeper.port }}
     {{- end }}
     {{- $extraConfig := tpl (include "clickhouse.extraConfig" . ) . -}}
-    {{- if not (empty $extraConfig) }}
+    {{- $extraUsers := tpl (include "clickhouse.extraUsers" . ) . -}}
+    {{- if not (and (empty $extraConfig) (empty $extraUsers)) }}
     files:
+        {{- if not (empty $extraConfig) }}
         config.d/extra_config.xml: |
           {{- tpl $extraConfig . | nindent 10 }}
-    {{- end }}
-    {{- $extraUsers := tpl (include "clickhouse.extraUsers" . ) . -}}
-    {{- if not (empty $extraUsers) }}
-    files:
+        {{- end }}
+        {{- if not (empty $extraUsers) }}
         users.d/extra_users.xml: |
           {{- tpl $extraUsers . | nindent 10 }}
+        {{- end }}
     {{- end }}
 
 {{ include "validate.clickhouse.keeper" . }}


### PR DESCRIPTION
#59 caused a regression in behavior with the `helm template` command. The `helm template` command is leveraged by ArgoCD ([docs](https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#declarative:~:text=Helm%20is%20only%20used%20to%20inflate%20charts%20with%20helm%20template.)).

# Original behavior

(Commit 1477292)
```sh
$ helm template chi-test charts/clickhouse | tail -n 10
#             key: password
#     clusters:
#       - name: chi-test
#         layout:
#           shardsCount: 1
#           replicasCount: 1
#     files:
#         config.d/extra_config.xml: |
#           <clickhouse>
#           </clickhouse>
```

# Before this PR

```sh
$ helm template chi-test charts/clickhouse | tail -n 10
# Error: template: clickhouse/templates/chi.yaml:198:28: executing "clickhouse/templates/chi.yaml" at <include "clickhouse.extraUsers" .>: error calling include: template: no template "clickhouse.extraUsers" associated with template "gotpl"
# 
# Use --debug flag to render out invalid YAML
```

# After this PR
Note that this PR also ensures that the `file:` block only shows up once; with the original template post #59, the `files:` block would appear twice.
```sh
$ helm template chi-test charts/clickhouse | tail -n 10
#           shardsCount: 1
#           replicasCount: 1
#     files:
#         config.d/extra_config.xml: |
#           <clickhouse>
#           </clickhouse>
#           
#         users.d/extra_users.xml: |
#           <clickhouse>
#           </clickhouse>
```