### PR TITLE
Add namespaceDomainPattern to Helm chart

### DIFF
--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -155,6 +155,7 @@ EOSQL
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| namespaceDomainPattern | string |  | Custom domain pattern used for DNS names of `Service` and `Pod` resources. Typically defined by the custom cluster domain of the Kubernetes cluster. The pattern follows the `%s` C-style printf format, e.g. '%s.svc.my.test'. If not specified, the default namespace domain suffix is `.svc.cluster.local`. |
 | clickhouse.antiAffinity | bool | `false` |  |
 | clickhouse.clusterSecret | object | `{"auto":true,"enabled":false,"value":"","valueFrom":{"secretKeyRef":{"key":"secret","name":""}}}` | Cluster secret configuration for secure inter-node communication |
 | clickhouse.clusterSecret.auto | bool | `true` | Auto-generate cluster secret (recommended for security) |

--- a/charts/clickhouse/templates/chi.yaml
+++ b/charts/clickhouse/templates/chi.yaml
@@ -201,5 +201,8 @@ spec:
         users.d/extra_users.xml: |
           {{- tpl $extraUsers . | nindent 10 }}
     {{- end }}
+  {{- if not (empty .Values.namespaceDomainPattern) }}
+  namespaceDomainPattern: {{ .Values.namespaceDomainPattern | quote }}
+  {{- end }}
 
 {{ include "validate.clickhouse.keeper" . }}

--- a/charts/clickhouse/templates/chk.yaml
+++ b/charts/clickhouse/templates/chk.yaml
@@ -129,4 +129,7 @@ spec:
                   cpu: "{{ $.Values.keeper.resources.cpuLimitsMs }}"
                   memory: "{{ $.Values.keeper.resources.memoryLimitsMiB }}"
     {{- end }}
+  {{- if not (empty .Values.namespaceDomainPattern) }}
+  namespaceDomainPattern: {{ .Values.namespaceDomainPattern | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/clickhouse/values.schema.json
+++ b/charts/clickhouse/values.schema.json
@@ -10,6 +10,10 @@
       "type": "string",
       "description": "Overrides the full name of the chart."
     },
+    "namespaceDomainPattern": {
+      "type": "string",
+      "description": "Custom cluster domain of Kubernetes cluster."
+    },
     "clickhouse": {
       "type": "object",
       "properties": {

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -4,6 +4,12 @@ nameOverride: ""
 # @ignore
 fullnameOverride: ""
 
+# -- Custom domain pattern used for DNS names of `Service` and `Pod` resources.
+# Typically defined by the custom cluster domain of the Kubernetes cluster.
+# The pattern follows the `%s` C-style printf format, e.g. %s.svc.my.test.
+# If not specified, the default namespace domain suffix is `.svc.cluster.local`.
+namespaceDomainPattern: ""
+
 # Configure ClickHouse Installation and Pod Template
 clickhouse:
   defaultUser:

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -6,7 +6,7 @@ fullnameOverride: ""
 
 # -- Custom domain pattern used for DNS names of `Service` and `Pod` resources.
 # Typically defined by the custom cluster domain of the Kubernetes cluster.
-# The pattern follows the `%s` C-style printf format, e.g. %s.svc.my.test.
+# The pattern follows the `%s` C-style printf format, e.g. '%s.svc.my.test'.
 # If not specified, the default namespace domain suffix is `.svc.cluster.local`.
 namespaceDomainPattern: ""
 


### PR DESCRIPTION
The CHI and CHK CRDs have supported custom Kubernetes (k8s) cluster domains for a long time now (see Altinity/clickhouse-operator#374).

This has never been plumbed through to the Helm chart, resulting in the deployed operator failing to connect to any of the replica instances if the k8s cluster has a custom domain, with errors filling the logs like these:
```
E0917 03:56:00.307519       1 connection.go:90] connect():FAILED Ping(http://clickhouse_operator:***@chi-clickhouse-corp-ch-0-0.clickhouse.svc.cluster.local:8123/). Err: doRequest: transport failed to send a request to ClickHouse: dial tcp: lookup chi-clickhouse-corp-ch-0-0.clickhouse.svc.cluster.local on 169.254.169.254:53: no such host
E0917 03:56:00.307579       1 connection.go:179] QueryContext():FAILED connect(http://clickhouse_operator:***@chi-clickhouse-corp-ch-0-0.clickhouse.svc.cluster.local:8123/) for SQL: SELECT version()
W0917 03:56:00.307600       1 cluster.go:91] QueryAny():FAILED to run query on: chi-clickhouse-corp-ch-0-0.clickhouse.svc.cluster.local of [chi-clickhouse-corp-ch-0-0.clickhouse.svc.cluster.local] skip to next. err: FAILED connect(http://clickhouse_operator:***@chi-clickhouse-corp-ch-0-0.clickhouse.svc.cluster.local:8123/) for SQL: SELECT version()
E0917 03:56:00.307630       1 cluster.go:95] QueryAny():FAILED to run query on all hosts [chi-clickhouse-corp-ch-0-0.clickhouse.svc.cluster.local]
W0917 03:56:00.307665       1 worker-app-version.go:37] getHostClickHouseVersion():Host:0-0[0/0]:clickhouse/clickhouse:Failed to get ClickHouse version on host: 0-0 err: FAILED to run query on all hosts [chi-clickhouse-corp-ch-0-0.clickhouse.svc.cluster.local]
W0917 03:56:00.307691       1 worker-app-version.go:54] func1():Host:0-0[0/0]:clickhouse/clickhouse:Host is NOT alive: 0-0
```
The volume of errors makes it very hard to debug other operations, such as rolling out updates for the CHI and CHK resources.

This PR plumbs `namespaceDomainPattern` through so it's exposed via the Helm chart.

# Tests

Tested with `helm template ...` with the `charts/clickhouse/values.yaml` file, although I needed to test this PR on top of the changes from #60 because `helm template ...` wouldn't work without it (see description in that PR).

## When `namespaceDomainPattern` is set and non-empty

```sh
$ git diff charts/clickhouse/values.yaml
# diff --git a/charts/clickhouse/values.yaml b/charts/clickhouse/values.yaml
# index 16bf07f..d9c5046 100644
# --- a/charts/clickhouse/values.yaml
# +++ b/charts/clickhouse/values.yaml
# @@ -8,7 +8,7 @@ fullnameOverride: ""
#  # Typically defined by the custom cluster domain of the Kubernetes cluster.
#  # The pattern follows the `%s` C-style printf format, e.g. %s.svc.my.test.
#  # If not specified, the default namespace domain suffix is `.svc.cluster.local`.
# -namespaceDomainPattern: ""
# +namespaceDomainPattern: "%s.svc"
#  
#  # Configure ClickHouse Installation and Pod Template
#  clickhouse:
# @@ -159,7 +159,7 @@ clickhouse:
#  keeper:
#    # -- Whether to enable Keeper.
#    # Required for replicated tables.
# -  enabled: false
# +  enabled: true
#    # -- Number of keeper replicas.
#    # Must be an odd number.
#    # !! DO NOT CHANGE AFTER INITIAL DEPLOYMENT
```
Note the key `.spec.namespaceDomainPattern` being selected:
```sh
$ helm template chi-test charts/clickhouse -f charts/clickhouse/values.yaml | yq 'select(.kind == "ClickHouseInstallation" or .kind == "ClickHouseKeeperInstallation") | .kind, .spec.namespaceDomainPattern | select(. != null)'
# ClickHouseInstallation
# %s.svc
# ---
# ClickHouseKeeperInstallation
# %s.svc
```

## Default, aka when `namespaceDomainPattern` is empty/not specified

Note the lack of `.spec.namespaceDomainPattern` output:
```sh
$ helm template chi-test charts/clickhouse -f charts/clickhouse/values.yaml | yq 'select(.kind == "ClickHouseInstallation" or .kind == "ClickHouseKeeperInstallation") | .kind, .spec.namespaceDomainPattern | select(. != null)'
# ClickHouseInstallation
# ---
# ClickHouseKeeperInstallation
```