### PR TITLE
feat: allow configuring clusterSecret without using the secure port

### DIFF
--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -159,6 +159,7 @@ EOSQL
 | clickhouse.clusterSecret | object | `{"auto":true,"enabled":false,"value":"","valueFrom":{"secretKeyRef":{"key":"secret","name":""}}}` | Cluster secret configuration for secure inter-node communication |
 | clickhouse.clusterSecret.auto | bool | `true` | Auto-generate cluster secret (recommended for security) |
 | clickhouse.clusterSecret.enabled | bool | `false` | Whether to enable secure cluster communication |
+| clickhouse.clusterSecret.secure | bool | `false` | Whether to put inter-node communication behind the SSL port (WARNING: this requires that you use extraConfig to set up SSL) |
 | clickhouse.clusterSecret.value | string | `""` | Plaintext cluster secret value (not recommended for production) |
 | clickhouse.clusterSecret.valueFrom | object | `{"secretKeyRef":{"key":"secret","name":""}}` | Reference to an existing Kubernetes secret containing the cluster secret |
 | clickhouse.clusterSecret.valueFrom.secretKeyRef.key | string | `"secret"` | Key in the secret that contains the cluster secret value |

--- a/charts/clickhouse/templates/chi.yaml
+++ b/charts/clickhouse/templates/chi.yaml
@@ -132,7 +132,9 @@ spec:
     clusters:
       - name: {{ include "clickhouse.clustername" . }}
         {{- if .Values.clickhouse.clusterSecret.enabled }}
+        {{- if .Values.clickhouse.clusterSecret.secure }}
         secure: "yes"
+        {{- end }}
         secret:
           {{- if .Values.clickhouse.clusterSecret.auto }}
           auto: "true"

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -26,8 +26,10 @@ clickhouse:
 
   # -- Cluster secret configuration for secure inter-node communication
   clusterSecret:
-    # -- Whether to enable secure cluster communication
+    # -- Whether to enable secret-based cluster communication
     enabled: false
+    # -- Whether to secure this behind the SSL port
+    secure: false
     # -- Auto-generate cluster secret (recommended for security)
     auto: true
     # -- Plaintext cluster secret value (not recommended for production)


### PR DESCRIPTION
As it stands, the `clusterSecret` functionality is mostly useless because there's no way to configure SSL in this helm chart, and it forcibly enables the `secure` mode (which... moves all cluster communication to use SSL). This splits up those settings.

Please let me know if I'm misunderstanding how this feature works.