### PR TITLE
Add support for external password secrets

### DIFF
--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -167,6 +167,7 @@ EOSQL
 | clickhouse.defaultUser.allowExternalAccess | bool | `false` | Allow the default user to access ClickHouse from any IP. If set, will override `hostIP` to always be `0.0.0.0/0`. |
 | clickhouse.defaultUser.hostIP | string | `"127.0.0.1/32"` |  |
 | clickhouse.defaultUser.password | string | `""` |  |
+| clickhouse.defaultUser.password_secret_name | string | `""` | Name of an existing Kubernetes secret containing the default user password. If set, the password will be read from the secret instead of using the password field. The secret should contain a key named 'password'. |
 | clickhouse.extraConfig | string | `"<clickhouse>\n</clickhouse>\n"` | Miscellanous config for ClickHouse (in xml format) |
 | clickhouse.extraUsers | string | `"<clickhouse>\n</clickhouse>\n"` | Additional users config for ClickHouse (in xml format) |
 | clickhouse.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/clickhouse/templates/chi.yaml
+++ b/charts/clickhouse/templates/chi.yaml
@@ -128,7 +128,7 @@ spec:
       default/password:
         valueFrom:
           secretKeyRef:
-            name: {{ include "clickhouse.credentialsName" . }}
+            name: {{ .Values.clickhouse.defaultUser.password_secret_name | default (include "clickhouse.credentialsName" .) | quote }}
             key: password
       {{- range .Values.clickhouse.users }}
       {{ required "A user must have a name" .name }}/access_management: {{ .accessManagement | default 0}}

--- a/charts/clickhouse/templates/credentials.yaml
+++ b/charts/clickhouse/templates/credentials.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.clickhouse.defaultUser.password_secret_name }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,3 +7,4 @@ type: Opaque
 stringData:
   user: "default"
   password: "{{ .Values.clickhouse.defaultUser.password }}"
+{{- end }}

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -14,6 +14,10 @@ namespaceDomainPattern: ""
 clickhouse:
   defaultUser:
     password: ""
+    # -- Name of an existing Kubernetes secret containing the default user password.
+    # If set, the password will be read from the secret instead of using the password field.
+    # The secret should contain a key named 'password'.
+    password_secret_name: ""
     # -- Allow the default user to access ClickHouse from any IP.
     # If set, will override `hostIP` to always be `0.0.0.0/0`.
     allowExternalAccess: false


### PR DESCRIPTION
# Add support for external password secrets in ClickHouse Helm chart

## Summary
Enhanced the ClickHouse Helm chart to support using existing Kubernetes secrets for the default user password, providing better security and integration with external secret management systems.

## Changes
- **Added new configuration option**: `clickhouse.defaultUser.password_secret_name`
  - Allows specifying an existing Kubernetes secret containing the default user password
  - Secret should contain a key named 'password'
  
- **Updated chart templates**:
  - Modified `chi.yaml` to use external secret when `password_secret_name` is specified
  - Updated `credentials.yaml` to conditionally create the default secret only when no external secret is specified
  
- **Documentation updates**:
  - Added parameter documentation in README.md
  - Added inline comments in values.yaml explaining the new feature

## Benefits
- **Improved security**: Passwords can be managed externally through dedicated secret management tools
- **Better integration**: Works seamlessly with Vault, Sealed Secrets, or other Kubernetes secret management solutions
- **Backward compatibility**: Existing deployments continue to work without changes
- **Flexible deployment**: Supports both inline password definition and external secret references

## Files Modified
- `charts/clickhouse/README.md`: Added parameter documentation
- `charts/clickhouse/templates/chi.yaml`: Updated to support external secret reference
- `charts/clickhouse/templates/credentials.yaml`: Made secret creation conditional
- `charts/clickhouse/values.yaml`: Added new configuration parameter with documentation

## Usage Example
```yaml
clickhouse:
  defaultUser:
    password_secret_name: "my-clickhouse-credentials"
```

This change enhances the chart's flexibility while maintaining full backward compatibility with existing configurations.