### PR TITLE
feat: Add support for additional containerPorts for clickhouse pods

### DIFF
--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -168,6 +168,7 @@ EOSQL
 | clickhouse.defaultUser.hostIP | string | `"127.0.0.1/32"` |  |
 | clickhouse.defaultUser.password | string | `""` |  |
 | clickhouse.extraConfig | string | `"<clickhouse>\n</clickhouse>\n"` | Miscellanous config for ClickHouse (in xml format) |
+| clickhouse.extraPorts | list | `[]` | Additional ports to expose in the ClickHouse container |
 | clickhouse.extraUsers | string | `"<clickhouse>\n</clickhouse>\n"` | Additional users config for ClickHouse (in xml format) |
 | clickhouse.image.pullPolicy | string | `"IfNotPresent"` |  |
 | clickhouse.image.repository | string | `"altinity/clickhouse-server"` |  |

--- a/charts/clickhouse/templates/_helpers.tpl
+++ b/charts/clickhouse/templates/_helpers.tpl
@@ -88,6 +88,16 @@ Pod Template Base
                 {{- toYaml .Values.clickhouse.securityContext | nindent 16 }}
               image: "{{ .Values.clickhouse.image.repository }}:{{ .Values.clickhouse.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.clickhouse.image.pullPolicy }}
+              ports:
+                - name: http
+                  containerPort: 8123
+                - name: client
+                  containerPort: 9000
+                - name: interserver
+                  containerPort: 9009
+                {{- if .Values.clickhouse.extraPorts }}
+                {{- toYaml .Values.clickhouse.extraPorts | nindent 16 }}
+                {{- end }}
               {{- with .Values.clickhouse.livenessProbe }}
               livenessProbe:
                 {{- toYaml . | nindent 16 }}

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -138,6 +138,15 @@ clickhouse:
   # @ignore
   topologySpreadConstraints: []
 
+
+  # -- Additional ports to expose in the ClickHouse container
+  # Example:
+  # extraPorts:
+  #   - name: custom-port
+  #     containerPort: 8080
+  #     protocol: TCP
+  extraPorts: []
+
   # -- Miscellanous config for ClickHouse (in xml format)
   extraConfig: |
     <clickhouse>


### PR DESCRIPTION
## Summary
Enhanced the ClickHouse Helm chart to support exposing additional container ports beyond the default ClickHouse ports, enabling better integration with monitoring systems and custom services.

## Changes
Added new configuration option: `clickhouse.extraPorts`

- Allows specifying additional ports to expose in the ClickHouse container
- Supports standard Kubernetes port configuration with name, containerPort, and protocol
- Enables exposure of custom services, monitoring endpoints, and sidecar communication

**Updated chart templates:**
- Modified `_helpers.tpl` to include extraPorts in the pod template port configuration
- Added conditional rendering to include extra ports alongside default ClickHouse ports (8123, 9000, 9009) that was in the existing configuration for backward compatability

**Documentation updates:**
- Added parameter documentation in `README.md` Values table
- Added inline comments in `values.yaml` with usage example

## Benefits
- **Enhanced monitoring**: Enables exposure of custom ports to expose metrics endpoints
- **Backward compatibility**: Existing deployments continue to work without changes

## Files Modified
- `charts/clickhouse/README.md`: Added parameter documentation
- `charts/clickhouse/templates/_helpers.tpl`: Updated pod template to support extra ports
- `charts/clickhouse/values.yaml`: Added new configuration parameter with example

## Usage Example
```yaml
clickhouse:
  extraPorts:
    - name: http-metrics
      containerPort: 8001
  extraConfig: |
    <clickhouse>
      <prometheus>
        <endpoint>/metrics</endpoint>
        <port>8001</port>
      </prometheus>
    </clickhouse>
```

This change enhances the chart's flexibility for monitoring and custom service integration while maintaining full backward compatibility with existing configurations.