### PR TITLE
feat: Add extraContainers and extraVolumes to ClickHouse pods

### DIFF
--- a/charts/clickhouse-eks/Chart.yaml
+++ b/charts/clickhouse-eks/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: clickhouse-eks
 description: A Helm chart for ClickHouse running on AWS EKS across AZs using a nodeSelector to pin resources to run on specific VMs types
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "1.16.0"

--- a/charts/clickhouse-eks/README.md
+++ b/charts/clickhouse-eks/README.md
@@ -1,6 +1,6 @@
 # clickhouse-eks
 
-![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 A Helm chart for ClickHouse running on AWS EKS across AZs using a nodeSelector to pin resources to run on specific VMs types
 

--- a/charts/clickhouse-eks/README.md
+++ b/charts/clickhouse-eks/README.md
@@ -52,6 +52,8 @@ kubectl exec -it chi-eks-dev-0-0-0 --namespace clickhouse -- clickhouse-client
 |-----|------|---------|-------------|
 | all.metadata.labels.application_group | string | `"eks"` | The name of the application group |
 | clickhouse.cluster | string | `"dev"` | Cluster name |
+| clickhouse.extraContainers | object | `{}` | Extra containers for clickhouse pods |
+| clickhouse.extraVolumes | object | `{}` | Extra volumes for clickhouse pods |
 | clickhouse.image | string | `"altinity/clickhouse-server:24.3.12.76.altinitystable"` | ClickHouse server image |
 | clickhouse.keeper_name | string | `"keeper-eks"` | Name of the keeper cluster |
 | clickhouse.name | string | `"eks"` | Metadata name |

--- a/charts/clickhouse-eks/README.md
+++ b/charts/clickhouse-eks/README.md
@@ -52,8 +52,8 @@ kubectl exec -it chi-eks-dev-0-0-0 --namespace clickhouse -- clickhouse-client
 |-----|------|---------|-------------|
 | all.metadata.labels.application_group | string | `"eks"` | The name of the application group |
 | clickhouse.cluster | string | `"dev"` | Cluster name |
-| clickhouse.extraContainers | object | `{}` | Extra containers for clickhouse pods |
-| clickhouse.extraVolumes | object | `{}` | Extra volumes for clickhouse pods |
+| clickhouse.extraContainers | list | `[]` | Extra containers for clickhouse pods |
+| clickhouse.extraVolumes | list | `[]` | Extra volumes for clickhouse pods |
 | clickhouse.image | string | `"altinity/clickhouse-server:24.3.12.76.altinitystable"` | ClickHouse server image |
 | clickhouse.keeper_name | string | `"keeper-eks"` | Name of the keeper cluster |
 | clickhouse.name | string | `"eks"` | Metadata name |

--- a/charts/clickhouse-eks/templates/chi.yaml
+++ b/charts/clickhouse-eks/templates/chi.yaml
@@ -37,25 +37,33 @@ spec:
           port: 2181
   templates:
     podTemplates:
-      {{- range .Values.clickhouse.zones }}
-      - name: replica-in-zone-{{ . }}
+      {{- $root := . }}
+      {{- range $zone := $root.Values.clickhouse.zones }}
+      - name: replica-in-zone-{{ $zone }}
         zone:
           values:
-            - {{ . }}
+            - {{ $zone }}
         podDistribution:
           - type: ClickHouseAntiAffinity
             scope: ClickHouseInstallation
         spec:
           containers:
-          - name: clickhouse
-            image: {{ $.Values.clickhouse.image }}
+            - name: clickhouse
+              image: {{ $root.Values.clickhouse.image }}
+            {{- with $root.Values.clickhouse.extraContainers }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           nodeSelector:
-            node.kubernetes.io/instance-type: {{ $.Values.clickhouse.node_selector }}
+            node.kubernetes.io/instance-type: {{ $root.Values.clickhouse.node_selector }}
           tolerations:
             - key: "dedicated"
               operator: "Equal"
               value: "clickhouse"
               effect: "NoSchedule"
+          {{- with $root.Values.clickhouse.extraVolumes }}
+          volumes:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- end }}
     volumeClaimTemplates:
       - name: storage
@@ -119,4 +127,3 @@ spec:
             - name: tcp
               port: 9000
               targetPort: 9000
-

--- a/charts/clickhouse-eks/values.yaml
+++ b/charts/clickhouse-eks/values.yaml
@@ -29,6 +29,12 @@ clickhouse:
   # -- ClickHouse server image
   image: "altinity/clickhouse-server:24.3.12.76.altinitystable"
 
+  # -- Extra volumes for clickhouse pods
+  extraVolumes: []
+
+  # -- Extra containers for clickhouse pods
+  extraContainers: []
+
   # -- Possible service types are `cluster-ip`, `internal-loadbalancer` and `external-loadbalancer`
   service_type: cluster-ip
 

--- a/charts/clickhouse-eks/values.yaml
+++ b/charts/clickhouse-eks/values.yaml
@@ -30,10 +30,10 @@ clickhouse:
   image: "altinity/clickhouse-server:24.3.12.76.altinitystable"
 
   # -- Extra volumes for clickhouse pods
-  extraVolumes: {}
+  extraVolumes: []
 
   # -- Extra containers for clickhouse pods
-  extraContainers: {}
+  extraContainers: []
 
   # -- Possible service types are `cluster-ip`, `internal-loadbalancer` and `external-loadbalancer`
   service_type: cluster-ip

--- a/charts/clickhouse-eks/values.yaml
+++ b/charts/clickhouse-eks/values.yaml
@@ -30,10 +30,10 @@ clickhouse:
   image: "altinity/clickhouse-server:24.3.12.76.altinitystable"
 
   # -- Extra volumes for clickhouse pods
-  extraVolumes: []
+  extraVolumes: {}
 
   # -- Extra containers for clickhouse pods
-  extraContainers: []
+  extraContainers: {}
 
   # -- Possible service types are `cluster-ip`, `internal-loadbalancer` and `external-loadbalancer`
   service_type: cluster-ip

--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for creating a ClickHouse® Cluster with the Altinity Operator for ClickHouse
 type: application
-version: 0.3.3
+version: 0.3.5
 appVersion: "25.3.6.10034"
 
 dependencies:

--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for creating a ClickHouse® Cluster with the Altinity Operator for ClickHouse
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: "25.3.6.10034"
 
 dependencies:

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -167,7 +167,9 @@ EOSQL
 | clickhouse.defaultUser.hostIP | string | `"127.0.0.1/32"` |  |
 | clickhouse.defaultUser.password | string | `""` |  |
 | clickhouse.extraConfig | string | `"<clickhouse>\n</clickhouse>\n"` | Miscellanous config for ClickHouse (in xml format) |
+| clickhouse.extraContainers | list | `[]` |  |
 | clickhouse.extraUsers | string | `"<clickhouse>\n</clickhouse>\n"` | Additional users config for ClickHouse (in xml format) |
+| clickhouse.extraVolumes | list | `[]` | Extra volumes for clickhouse pods |
 | clickhouse.image.pullPolicy | string | `"IfNotPresent"` |  |
 | clickhouse.image.repository | string | `"altinity/clickhouse-server"` |  |
 | clickhouse.image.tag | string | `"25.3.6.10034.altinitystable"` | Override the image tag for a specific version |

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -1,5 +1,5 @@
 # clickhouse
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.3.6.10034](https://img.shields.io/badge/AppVersion-25.3.6.10034-informational?style=flat-square)
+![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.3.6.10034](https://img.shields.io/badge/AppVersion-25.3.6.10034-informational?style=flat-square)
 
 A Helm chart for creating a ClickHouse® Cluster with the Altinity Operator for ClickHouse
 

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -1,5 +1,5 @@
 # clickhouse
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.3.6.10034](https://img.shields.io/badge/AppVersion-25.3.6.10034-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.3.6.10034](https://img.shields.io/badge/AppVersion-25.3.6.10034-informational?style=flat-square)
 
 A Helm chart for creating a ClickHouse® Cluster with the Altinity Operator for ClickHouse
 
@@ -154,12 +154,11 @@ EOSQL
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| namespaceDomainPattern | string |  | Custom domain pattern used for DNS names of `Service` and `Pod` resources. Typically defined by the custom cluster domain of the Kubernetes cluster. The pattern follows the `%s` C-style printf format, e.g. '%s.svc.my.test'. If not specified, the default namespace domain suffix is `.svc.cluster.local`. |
 | clickhouse.antiAffinity | bool | `false` |  |
-| clickhouse.clusterSecret | object | `{"auto":true,"enabled":false,"value":"","valueFrom":{"secretKeyRef":{"key":"secret","name":""}}}` | Cluster secret configuration for secure inter-node communication |
+| clickhouse.clusterSecret | object | `{"auto":true,"enabled":false,"secure":false,"value":"","valueFrom":{"secretKeyRef":{"key":"secret","name":""}}}` | Cluster secret configuration for secure inter-node communication |
 | clickhouse.clusterSecret.auto | bool | `true` | Auto-generate cluster secret (recommended for security) |
-| clickhouse.clusterSecret.enabled | bool | `false` | Whether to enable secure cluster communication |
-| clickhouse.clusterSecret.secure | bool | `false` | Whether to put inter-node communication behind the SSL port (WARNING: this requires that you use extraConfig to set up SSL) |
+| clickhouse.clusterSecret.enabled | bool | `false` | Whether to enable secret-based cluster communication |
+| clickhouse.clusterSecret.secure | bool | `false` | Whether to secure this behind the SSL port |
 | clickhouse.clusterSecret.value | string | `""` | Plaintext cluster secret value (not recommended for production) |
 | clickhouse.clusterSecret.valueFrom | object | `{"secretKeyRef":{"key":"secret","name":""}}` | Reference to an existing Kubernetes secret containing the cluster secret |
 | clickhouse.clusterSecret.valueFrom.secretKeyRef.key | string | `"secret"` | Key in the secret that contains the cluster secret value |
@@ -219,4 +218,5 @@ EOSQL
 | keeper.tolerations | list | `[]` |  |
 | keeper.volumeClaimAnnotations | object | `{}` |  |
 | keeper.zoneSpread | bool | `false` |  |
+| namespaceDomainPattern | string | `""` | Custom domain pattern used for DNS names of `Service` and `Pod` resources. Typically defined by the custom cluster domain of the Kubernetes cluster. The pattern follows the `%s` C-style printf format, e.g. '%s.svc.my.test'. If not specified, the default namespace domain suffix is `.svc.cluster.local`. |
 | operator.enabled | bool | `true` | Whether to enable the Altinity Operator for ClickHouse. Disable if you already have the Operator installed cluster-wide. |

--- a/charts/clickhouse/templates/_helpers.tpl
+++ b/charts/clickhouse/templates/_helpers.tpl
@@ -104,11 +104,19 @@ Pod Template Base
               {{- end }}
               resources:
                 {{- toYaml .Values.clickhouse.resources | nindent 16 }}
-          {{- if .Values.clickhouse.initScripts.enabled }}
+            {{- with .Values.clickhouse.extraContainers }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if or .Values.clickhouse.initScripts.enabled .Values.clickhouse.extraVolumes }}
           volumes:
+            {{- if .Values.clickhouse.initScripts.enabled }}
             - name: init-scripts-configmap
               configMap:
                 name: {{ .Values.clickhouse.initScripts.configMapName }}
+            {{- end }}
+            {{- with .Values.clickhouse.extraVolumes }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.clickhouse.nodeSelector }}
           nodeSelector:

--- a/charts/clickhouse/values.schema.json
+++ b/charts/clickhouse/values.schema.json
@@ -258,7 +258,7 @@
           "description": "Miscellaneous users config for ClickHouse in XML format."
         },
         "extraContainers": {
-          "type": "object",
+          "type": "array",
           "description": "Extra containers for Clickhouse pod."
         },
         "extraVolumes": {

--- a/charts/clickhouse/values.schema.json
+++ b/charts/clickhouse/values.schema.json
@@ -258,7 +258,7 @@
           "description": "Miscellaneous users config for ClickHouse in XML format."
         },
         "extraContainers": {
-          "type": "array",
+          "type": "object",
           "description": "Extra containers for Clickhouse pod."
         },
         "extraVolumes": {

--- a/charts/clickhouse/values.schema.json
+++ b/charts/clickhouse/values.schema.json
@@ -257,6 +257,14 @@
           "type": "string",
           "description": "Miscellaneous users config for ClickHouse in XML format."
         },
+        "extraContainers": {
+          "type": "object",
+          "description": "Extra containers for Clickhouse pod."
+        },
+        "extraVolumes": {
+          "type": "object",
+          "description": "Extra volumes for Clickhouse pod."
+        },
         "initScripts": {
           "type": "object",
           "description": "Configuration for init scripts via ConfigMap.",

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -148,10 +148,10 @@ clickhouse:
     </clickhouse>
 
   # @ignore
-  extraContainers: {}
+  extraContainers: []
 
   # @ignore
-  extraVolumes: {}
+  extraVolumes: []
 
   # -- Init scripts ConfigMap configuration
   initScripts:

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -148,10 +148,10 @@ clickhouse:
     </clickhouse>
 
   # @ignore
-  extraContainers: []
+  extraContainers: {}
 
   # @ignore
-  extraVolumes: []
+  extraVolumes: {}
 
   # -- Init scripts ConfigMap configuration
   initScripts:

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -147,11 +147,10 @@ clickhouse:
     <clickhouse>
     </clickhouse>
 
-  # @ignore
-  extraContainers: {}
+  extraContainers: []
 
-  # @ignore
-  extraVolumes: {}
+  # -- Extra volumes for clickhouse pods
+  extraVolumes: []
 
   # -- Init scripts ConfigMap configuration
   initScripts:

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -147,6 +147,12 @@ clickhouse:
     <clickhouse>
     </clickhouse>
 
+  # @ignore
+  extraContainers: {}
+
+  # @ignore
+  extraVolumes: {}
+
   # -- Init scripts ConfigMap configuration
   initScripts:
     # -- Set to true to enable init scripts feature


### PR DESCRIPTION
This PR adds support for injecting **extra containers** and **extra volumes** into ClickHouse pods via Helm values.

#### Main changes

* Added new values:
  * `clickhouse.extraContainers`
  * `clickhouse.extraVolumes`
* Updated templates in both `clickhouse` and `clickhouse-eks` charts to render these values in pod specs.
* Bumped chart version to **0.3.3** and updated READMEs and schema accordingly.

#### Why

This allows adding sidecars (e.g., Cloud SQL Proxy) or additional volumes without modifying chart templates.
