### PR TITLE
feat: Add multiple hostIPs for users

### DIFF
--- a/charts/clickhouse/templates/chi.yaml
+++ b/charts/clickhouse/templates/chi.yaml
@@ -132,7 +132,14 @@ spec:
             key: password
       {{- range .Values.clickhouse.users }}
       {{ required "A user must have a name" .name }}/access_management: {{ .accessManagement | default 0}}
+      {{- if kindIs "slice" .hostIP }}
+      {{ .name }}/networks/ip:
+      {{- range .hostIP }}
+      - {{ . | quote }}
+      {{- end }}
+      {{- else }}
       {{ .name }}/networks/ip: {{ .hostIP | default "0.0.0.0/0" | quote }}
+      {{- end }}
       {{- if .grants }}
       {{ .name }}/grants/query:
       {{- range .grants }}

--- a/charts/clickhouse/values.schema.json
+++ b/charts/clickhouse/values.schema.json
@@ -47,8 +47,20 @@
                 "pattern": "^[a-zA-Z0-9]+$"
               },
               "hostIP": {
-                "type": "string",
-                "description": "Mask for IPs allowed for this user.",
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "description": "Single IP mask allowed for this user."
+                  },
+                  {
+                    "type": "array",
+                    "description": "Multiple IP masks allowed for this user.",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                ],
+                "description": "Mask for IPs allowed for this user. Can be a string or array of strings.",
                 "default": "0.0.0.0/0"
               },
               "password_secret_name": {

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -26,8 +26,15 @@ clickhouse:
     # @default -- 127.0.0.1/32
     hostIP: 127.0.0.1/32
 
-  # Configure additional users
+  # -- Configure additional ClickHouse users.
   users: []
+  # users:
+  #   - name: app_user
+  #     hostIP: ["10.0.0.0/8"]  # default: "0.0.0.0/0"
+  #     accessManagement: 1  # default: 0
+  #     password_secret_name: "app-user-secret"  # secret must contain 'password' key
+  #     grants:
+  #       - "GRANT SELECT ON database.*"
 
   # -- number of replicas. If greater than 1, keeper must be enabled
   # or a keeper host should be provided under clickhouse.keeper.host.


### PR DESCRIPTION
This PR enhances the `clickhouse.users` value configuration to support multiple hostIPs.

**Changes**:
- Updated templates/chi.yaml to handle hostIP as either a string or array of strings
- Updated values.yaml documentation with example usage

**Why**
I want to use the Helm Chart in order to create a ClickHouse instance and my setup requires multiple network access control ranges.
