### PR TITLE
feat: add configurable anti-affinity scope

### DIFF
--- a/charts/clickhouse/templates/_helpers.tpl
+++ b/charts/clickhouse/templates/_helpers.tpl
@@ -56,7 +56,7 @@ Pod Distribution
 {{- define "clickhouse.podDistribution" -}}
 {{- if .Values.clickhouse.antiAffinity -}}
 - type: ClickHouseAntiAffinity
-  scope: ClickHouseInstallation
+  scope: {{ .Values.clickhouse.antiAffinityScope | default "ClickHouseInstallation" }}
 {{- end }}
 {{- end }}
 

--- a/charts/clickhouse/values.schema.json
+++ b/charts/clickhouse/values.schema.json
@@ -94,6 +94,18 @@
           "type": "boolean",
           "description": "If enabled, prevents ClickHouse pods from running on the same node."
         },
+        "antiAffinityScope": {
+          "type": "string",
+          "description": "Scope for anti-affinity policy when antiAffinity is enabled.",
+          "enum": [
+            "Shard",
+            "Replica",
+            "Cluster",
+            "ClickHouseInstallation",
+            "Namespace"
+          ],
+          "default": "ClickHouseInstallation"
+        },
         "keeper": {
           "type": "object",
           "properties": {

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -62,6 +62,17 @@ clickhouse:
   # If enabled, will prevent ClickHouse pods from running on the same node
   antiAffinity: false
 
+  # -- Scope for anti-affinity policy when antiAffinity is enabled.
+  # Determines the level at which pod distribution is enforced.
+  # Available scopes:
+  #   - ClickHouseInstallation: Pods from the same installation won't run on the same node (default)
+  #   - Shard: Pods from the same shard won't run on the same node
+  #   - Replica: Pods from the same replica won't run on the same node
+  #   - Cluster: Pods from the same cluster won't run on the same node
+  #   - Namespace: Pods from the same namespace won't run on the same node
+  # @default -- ClickHouseInstallation
+  antiAffinityScope: "ClickHouseInstallation"
+
   # -- Keeper connection settings for ClickHouse instances.
   keeper:
     # -- Specify a keeper host.


### PR DESCRIPTION
Introduce `antiAffinityScope` parameter to allow finer control over pod distribution policies. Users can now specify the scope level for anti-affinity rules when `antiAffinity` is enabled, supporting values like Shard, Replica, Cluster, ClickHouseInstallation, and Namespace.

This provides more granular control over pod placement strategies for different deployment scenarios while maintaining backward compatibility with the default ClickHouseInstallation scope.

**Why/Context:** I am starting a new ClickHouse deployment at my job (exploring the technology) with a defined a certain amount of shards and replicas (2x5). However, I am getting scheduling issues because there are not enough nodes in the k8s cluster to accommodate my configuration. I would like at least to make sure that different replica run on different nodes. Moving forward, we will likely add new nodes to the k8s cluster, or even create dedicated pools for ClickHouse, but the project isn't there yet.