### PR TITLE
fix(docs): update connection command in NOTES.txt for ClickHouse client

### DIFF
--- a/charts/clickhouse/templates/NOTES.txt
+++ b/charts/clickhouse/templates/NOTES.txt
@@ -22,7 +22,7 @@ Your ClickHouseInstallation resource has been created.
 Once the cluster is available you can connect with:
 
   kubectl -n {{ .Release.Namespace }} exec -it \
-    chi-{{ include "clickhouse.clustername" . }}-clickhouse-{{ include "clickhouse.clustername" . }}-0-0-0 \
+    chi-{{ include "clickhouse.fullname" . }}-{{ include "clickhouse.clustername" . }}-0-0-0 \
     clickhouse-client
 
 Or if you'd like to connect a client you can use port forwarding:


### PR DESCRIPTION
Fix incorrect pod name reference in `NOTES.txt` for ClickHouse Helm chart. The template used `-clickhouse-` hardcoded in the pod name, which doesn’t match the actual pod naming convention from the ClickHouse Operator. Updated to use `clickhouse.fullname` helper for accurate pod name generation.
