### PR TITLE
fix(keeper): correct CPU millicores formatting in resource specs

### DIFF
--- a/charts/clickhouse/templates/chk.yaml
+++ b/charts/clickhouse/templates/chk.yaml
@@ -123,10 +123,10 @@ spec:
               {{- end }}
               resources:
                 requests:
-                  cpu: "{{ $.Values.keeper.resources.cpuRequestsMs }}"
+                  cpu: "{{ $.Values.keeper.resources.cpuRequestsMs }}m"
                   memory: "{{ $.Values.keeper.resources.memoryRequestsMiB }}"
                 limits:
-                  cpu: "{{ $.Values.keeper.resources.cpuLimitsMs }}"
+                  cpu: "{{ $.Values.keeper.resources.cpuLimitsMs }}m"
                   memory: "{{ $.Values.keeper.resources.memoryLimitsMiB }}"
     {{- end }}
   {{- if not (empty .Values.namespaceDomainPattern) }}

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -219,10 +219,10 @@ keeper:
   zoneSpread: false
   metricsPort: ""
   resources:
-    cpuRequestsMs: 2
-    memoryRequestsMiB: 3Gi
-    cpuLimitsMs: 3
-    memoryLimitsMiB: 3Gi
+    cpuRequestsMs: 100
+    memoryRequestsMiB: 512Mi
+    cpuLimitsMs: 500
+    memoryLimitsMiB: 1Gi
 
 operator:
   # -- Whether to enable the Altinity Operator for ClickHouse.


### PR DESCRIPTION
Append 'm' suffix to keeper CPU resource values so they are correctly interpreted as millicores instead of whole CPUs. This fixes keeper pods being unschedulable due to requesting hundreds of CPUs.

Also update default values from 2-3 CPUs to 100m-500m millicores.