### PR TITLE
bug fix

### DIFF
--- a/charts/clickhouse/templates/_helpers.tpl
+++ b/charts/clickhouse/templates/_helpers.tpl
@@ -57,8 +57,6 @@ Pod Distribution
 {{- if .Values.clickhouse.antiAffinity -}}
 - type: ClickHouseAntiAffinity
   scope: {{ .Values.clickhouse.antiAffinityScope | default "ClickHouseInstallation" }}
-{{- else -}}
-[]
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
[INFO] Installing/Upgrading ClickHouse database server...
level=INFO msg="warning: destination for clickhouse.clickhouse.extraContainers is a table. Ignoring non-table value ([])"
level=INFO msg="warning: destination for clickhouse.clickhouse.extraVolumes is a table. Ignoring non-table value ([])"
level=INFO msg="warning: destination for clickhouse.clickhouse.extraContainers is a table. Ignoring non-table value ([])"
level=INFO msg="warning: destination for clickhouse.clickhouse.extraVolumes is a table. Ignoring non-table value ([])"
level=WARN msg="upgrade failed" name=clickhouse error="failed to create resource: [ClickHouseInstallation.clickhouse.altinity.com](http://clickhouseinstallation.clickhouse.altinity.com/) \"clickhouse\" is invalid: spec.templates.podTemplates[0].podDistribution: Invalid value: \"null\": spec.templates.podTemplates[0].podDistribution in body must be of type array: \"null\""
Error: UPGRADE FAILED: failed to create resource: [ClickHouseInstallation.clickhouse.altinity.com](http://clickhouseinstallation.clickhouse.altinity.com/) "clickhouse" is invalid: spec.templates.podTemplates[0].podDistribution: Invalid value: "null": spec.templates.podTemplates[0].podDistribution in body must be of type array: "null"