### PR TITLE
feat: auto-apply extraPorts to service templates

### DIFF
--- a/charts/clickhouse/templates/chi.yaml
+++ b/charts/clickhouse/templates/chi.yaml
@@ -55,6 +55,13 @@ spec:
             - name: tcp
               port: 9000
               targetPort: 9000
+            {{- if .Values.clickhouse.extraPorts }}
+            {{- range .Values.clickhouse.extraPorts }}
+            - name: {{ .name }}
+              port: {{ .containerPort }}
+              targetPort: {{ .containerPort }}
+            {{- end }}
+            {{- end }}
           selector:
             {{- include "clickhouse.selectorLabels" . | nindent 12 }}
       {{- if .Values.clickhouse.lbService.enabled }}


### PR DESCRIPTION
# Summary

- Auto-apply `clickhouse.extraPorts` from `values.yaml` to ClickHouse service templates.

- Keeps container ports and service ports in sync with a single configuration.
# Changes
- **Update** [charts/clickhouse/templates/chi.yaml](https://github.com/Altinity/helm-charts/blob/main/charts/clickhouse/templates/chi.yaml)

   - Add `extraPorts` to the regular service template.

   - Ensure `extraPorts` in the LoadBalancer service template maps `containerPort` → `port` and `targetPort`.

# Usage
Define once in `values.yaml`:
```
clickhouse:
  extraPorts:
    - name: custom-port
      containerPort: 8080
```
# Result
`custom-port` is exposed on:
- The ClickHouse container
- The regular Service
- The LoadBalancer Service (when enabled)