### PR TITLE
:package: (charts/clickhouse) upgrade clickhouse-operator chart to 0.25.6 from 0.25.5

### DIFF
--- a/charts/clickhouse/Chart.lock
+++ b/charts/clickhouse/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: altinity-clickhouse-operator
   repository: https://helm.altinity.com
-  version: 0.25.5
-digest: sha256:47275c2271832926b4c1041b238d068708bb847395dc1ab708bca183f6a707e4
-generated: "2025-10-31T11:49:40.820796477-04:00"
+  version: 0.25.6
+digest: sha256:3f08fc4cf1b1e1c06bf9cef5d9f5a753449075ea4a1fcc6434d0135655e4bc9d
+generated: "2026-01-12T10:31:38.524730059+01:00"

--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for creating a ClickHouse® Cluster with the Altinity Operator for ClickHouse
 type: application
-version: 0.3.7
+version: 0.3.8
 appVersion: "25.3.6.10034"
 
 dependencies:
   - name: altinity-clickhouse-operator
     repository: https://helm.altinity.com
-    version: 0.25.5
+    version: 0.25.6
     alias: operator
     condition: operator.enabled

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -1,5 +1,5 @@
 # clickhouse
-![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.3.6.10034](https://img.shields.io/badge/AppVersion-25.3.6.10034-informational?style=flat-square)
+![Version: 0.3.8](https://img.shields.io/badge/Version-0.3.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.3.6.10034](https://img.shields.io/badge/AppVersion-25.3.6.10034-informational?style=flat-square)
 
 A Helm chart for creating a ClickHouse® Cluster with the Altinity Operator for ClickHouse
 
@@ -15,7 +15,7 @@ A Helm chart for creating a ClickHouse® Cluster with the Altinity Operator for 
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://helm.altinity.com | operator(altinity-clickhouse-operator) | 0.25.5 |
+| https://helm.altinity.com | operator(altinity-clickhouse-operator) | 0.25.6 |
 
 ## Installing the Chart
 
@@ -80,6 +80,15 @@ helm install second-release altinity/clickhouse \
   --set operator.namespaceOverride=test \
   --set operator.rbac.namespaceScoped=true \
   --set operator.configs.files.config\\.yaml.watch.namespaces=\{test\}
+```
+
+By default, the operator installs the Custom Resource Definitions (CRDs) for ClickHouse resources.
+If you have already installed the CRDs separately, you can disable automatic CRD installation:
+
+```sh
+helm install third-release altinity/clickhouse --namespace clickhouse \
+  --namespace test \
+  --set operator.crds.enabled=false
 ```
 
 Consult the [Altinity ClickHouse Operator chart documentation](https://helm.altinity.com/)


### PR DESCRIPTION
Minor version bump adds CRDs management feature to the clickhouse-operator

Closes #114 