### PR TITLE
feat: expose security-context for pod and containers of the keeper

### DIFF
--- a/charts/clickhouse/templates/chk.yaml
+++ b/charts/clickhouse/templates/chk.yaml
@@ -113,8 +113,12 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          securityContext:
+            {{- toYaml .Values.keeper.podSecurityContext | nindent 12 }}
           containers:
             - name: clickhouse-keeper
+              securityContext:
+                {{- toYaml .Values.keeper.securityContext | nindent 16 }}
               image: "{{ $.Values.keeper.image }}:{{ $.Values.keeper.tag }}"
               {{- if not (empty $.Values.keeper.metricsPort) }}
               ports:

--- a/charts/clickhouse/values.schema.json
+++ b/charts/clickhouse/values.schema.json
@@ -369,6 +369,14 @@
           "type": "object",
           "description": "Annotations for Keeper pods."
         },
+        "podSecurityContext": {
+          "type": "object",
+          "description": "Pod security context for Keeper pods."
+        },
+        "securityContext": {
+          "type": "object",
+          "description": "Security context for Keeper containers."
+        },
         "volumeClaimAnnotations": {
           "type": "object",
           "description": "Annotations for Keeper volume claims."

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -223,6 +223,14 @@ keeper:
     memoryRequestsMiB: 512Mi
     cpuLimitsMs: 500
     memoryLimitsMiB: 1Gi
+  
+  # @ignore
+  podSecurityContext: {}
+    # runAsUser: 101
+    # runAsGroup: 101
+
+  # @ignore
+  securityContext: {}
 
 operator:
   # -- Whether to enable the Altinity Operator for ClickHouse.


### PR DESCRIPTION
During our deployment we noticed some limitations regarding the deployment of the keeper as we cannot control the security context to match potential rules enforced on the cluster.

This PR's goal is simply to expose these parameters to allow it to be user configurable.