### PR TITLE
feat: support keeper image pull secrets and extra manifests

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for creating a ClickHouse® Cluster with the Altinity Operator for ClickHouse
 type: application
-version: 0.3.8
+version: 0.3.9
 appVersion: "25.3.6.10034"
 
 dependencies:

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -255,8 +255,10 @@ EOSQL
 | clickhouse.shardsCount | int | `1` | number of shards. |
 | clickhouse.users | list | `[]` | Configure additional ClickHouse users. |
 | clickhouse.zones | list | `[]` |  |
+| extraManifests | list | `[]` | Extra manifests to deploy as an array |
 | keeper.enabled | bool | `false` | Whether to enable Keeper. Required for replicated tables. |
 | keeper.image | string | `"altinity/clickhouse-keeper"` |  |
+| keeper.imagePullSecrets | list | `[]` | Image pull secrets for Keeper pods |
 | keeper.localStorage.size | string | `"5Gi"` |  |
 | keeper.localStorage.storageClass | string | `""` |  |
 | keeper.metricsPort | string | `""` |  |

--- a/charts/clickhouse/templates/chk.yaml
+++ b/charts/clickhouse/templates/chk.yaml
@@ -113,6 +113,10 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with $.Values.keeper.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml $.Values.keeper.imagePullSecrets | nindent 12 }}
+          {{- end }}
           containers:
             - name: clickhouse-keeper
               image: "{{ $.Values.keeper.image }}:{{ $.Values.keeper.tag }}"

--- a/charts/clickhouse/templates/extra-manifests.yaml
+++ b/charts/clickhouse/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl . $ }}
+{{ end }}

--- a/charts/clickhouse/values.schema.json
+++ b/charts/clickhouse/values.schema.json
@@ -14,6 +14,13 @@
       "type": "string",
       "description": "Custom cluster domain of Kubernetes cluster."
     },
+    "extraManifests": {
+      "type": "array",
+      "description": "Extra manifests to deploy as an array.",
+      "items": {
+        "type": "string"
+      }
+    },
     "clickhouse": {
       "type": "object",
       "properties": {
@@ -357,6 +364,13 @@
         "nodeSelector": {
           "type": "object",
           "description": "Node selector for Keeper pods."
+        },
+        "imagePullSecrets": {
+          "type": "array",
+          "description": "Image pull secrets for Keeper pods.",
+          "items": {
+            "type": "object"
+          }
         },
         "tolerations": {
           "type": "array",

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -211,6 +211,7 @@ keeper:
     size: 5Gi
     storageClass: ""
   nodeSelector: {}
+  imagePullSecrets: []
   tolerations: []
   podAnnotations: {}
   volumeClaimAnnotations: {}
@@ -223,6 +224,16 @@ keeper:
     memoryRequestsMiB: 512Mi
     cpuLimitsMs: 500
     memoryLimitsMiB: 1Gi
+
+# Extra manifests to deploy as an array
+extraManifests: []
+  # - |
+  #   apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #    name: {{.Release.Name }}-config
+  #   data:
+  #     extra-data: "value"
 
 operator:
   # -- Whether to enable the Altinity Operator for ClickHouse.


### PR DESCRIPTION
Fixes #102 
Supports extraManifests (similar to open-telemetry, [prometheus](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/templates/extra-manifests.yaml)), eg. to manage a StorageClass.