### PR TITLE
Allow using non string chi setting as supported by CRD

### DIFF
--- a/charts/clickhouse/templates/chi.yaml
+++ b/charts/clickhouse/templates/chi.yaml
@@ -190,7 +190,12 @@ spec:
     {{- if .Values.clickhouse.settings }}
     settings:
     {{- range $key, $value := .Values.clickhouse.settings }}
-      {{ $key }}: "{{ $value }}"
+      {{- if kindIs "map" $value }}
+      {{ $key }}:
+        {{- toYaml $value | nindent 8 }}
+      {{- else }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
     {{- end }}
     {{- end }}
     clusters:


### PR DESCRIPTION
the chart was not able to support using non string settings for the clickhouse installation even tho it supports it. 
I simply added some logic to enable it.

For reference this was making it impossible to follow [this](https://github.com/Altinity/clickhouse-operator/blob/master/docs/security_hardening.md#securing-clickhouse-server-settings) hardening step to load secrets