### PR TITLE
feat(clickhouse): add imagePullSecrets support to keeper pod template

### DIFF
--- a/charts/clickhouse/templates/chk.yaml
+++ b/charts/clickhouse/templates/chk.yaml
@@ -117,6 +117,10 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with $.Values.keeper.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           containers:
             - name: clickhouse-keeper
               {{- with $.Values.keeper.securityContext }}

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -297,6 +297,10 @@ keeper:
   # @ignore
   securityContext: {}
 
+  # -- Image pull secrets for keeper pods.
+  # Example: [{"name": "my-registry-secret"}]
+  imagePullSecrets: []
+
 operator:
   # -- Whether to enable the Altinity Operator for ClickHouse.
   # Disable if you already have the Operator installed cluster-wide.


### PR DESCRIPTION
Closes #137

## What

Adds `keeper.imagePullSecrets` to `values.yaml` and wires it into the `podTemplates[].spec` block in `chk.yaml`.

## Why

`altinity/clickhouse-keeper` is hosted on `docker.io`, which rate-limits unauthenticated pulls. There is currently no way to pass an imagePullSecret to keeper pods, even though the `ClickHouseKeeperInstallation` CRD accepts arbitrary pod spec fields (`x-kubernetes-preserve-unknown-fields: true`). The equivalent field for the ClickHouse server pods (`clickhouse.imagePullSecrets`) already exists in the chart.

## Changes

- `charts/clickhouse/values.yaml`: add `keeper.imagePullSecrets: []` with doc comment, consistent with other keeper pod spec fields
- `charts/clickhouse/templates/chk.yaml`: render `imagePullSecrets` in the pod template spec using the same `{{- with }} / toYaml / nindent` pattern as `tolerations` and `podSecurityContext`